### PR TITLE
[Closes #3] feat: 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'		// mysql8.0.35
+
+	// oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/src/main/java/kuchat/server/common/config/JwtTokenFilter.java
+++ b/src/main/java/kuchat/server/common/config/JwtTokenFilter.java
@@ -1,0 +1,60 @@
+package kuchat.server.common.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import kuchat.server.domain.jwt.JwtTokenUtil;
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+// req에서 jwt token만 추출 -> 통과 시에만 권한 부여
+// -> 실패하면 권한 부여X, 다음 필터 적용하기
+@RequiredArgsConstructor
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private final MemberService memberService;
+    private final String secretkey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if(authorizationHeader == null){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if(!authorizationHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorizationHeader.split(" ")[1];
+
+        if(JwtTokenUtil.isExpired(token)){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String memberId = JwtTokenUtil.extractId(token);
+        Member loginMember = memberService.getMemberById(memberId);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                loginMember.getId(), null, List.of(new SimpleGrantedAuthority(loginMember.getRole().name()))
+        );
+        authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/kuchat/server/common/config/OAuth2SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/OAuth2SecurityConfig.java
@@ -1,0 +1,32 @@
+package kuchat.server.common.config;
+
+import kuchat.server.common.oauth.OAuth2Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class OAuth2SecurityConfig {
+    private final OAuth2Service OAuth2Service;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**", "/swagger-ui/**", "/oauth2/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2Login -> oauth2Login
+                        .loginPage("/login")            // 사용자 정의 로그인 페이지 URL 설정
+                        .defaultSuccessUrl("/oauth/login-info")         // 로그인 성공 후 리디렉션될 기본 URL 설정
+                        .failureUrl("/login-error")             // 로그인 실패 시 리디렉션될 URL 설정
+                        .userInfoEndpoint(userInfo -> userInfo.userService(OAuth2Service))            // 사용자 정보를 로드하는 데 사용할 UserService 설정
+                )
+                .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+                .build();
+    }
+}

--- a/src/main/java/kuchat/server/common/config/SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/SecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @RequiredArgsConstructor
-public class OAuth2SecurityConfig {
+public class SecurityConfig {
     private final OAuth2Service OAuth2Service;
 
     @Bean

--- a/src/main/java/kuchat/server/common/config/SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                         .failureUrl("/login-error")             // 로그인 실패 시 리디렉션될 URL 설정
                         .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2Service))            // 사용자 정보를 로드하는 데 사용할 UserService 설정
                 )
+                .addFilterBefore(new JwtTokenFilter(oAuth2Service, secretKey), UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
                 .build();
     }

--- a/src/main/java/kuchat/server/common/config/SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/SecurityConfig.java
@@ -2,20 +2,35 @@ package kuchat.server.common.config;
 
 import kuchat.server.common.oauth.OAuth2Service;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+
+@Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final OAuth2Service OAuth2Service;
+
+    @Value("${secret.jwt-secret-key}")
+    private static String secretKey;
+
+    private final OAuth2Service oAuth2Service;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sessionManagement -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**", "/swagger-ui/**", "/oauth2/**").permitAll()
                         .anyRequest().authenticated()
@@ -24,7 +39,7 @@ public class SecurityConfig {
                         .loginPage("/login")            // 사용자 정의 로그인 페이지 URL 설정
                         .defaultSuccessUrl("/oauth/login-info")         // 로그인 성공 후 리디렉션될 기본 URL 설정
                         .failureUrl("/login-error")             // 로그인 실패 시 리디렉션될 URL 설정
-                        .userInfoEndpoint(userInfo -> userInfo.userService(OAuth2Service))            // 사용자 정보를 로드하는 데 사용할 UserService 설정
+                        .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2Service))            // 사용자 정보를 로드하는 데 사용할 UserService 설정
                 )
                 .headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
                 .build();

--- a/src/main/java/kuchat/server/common/config/SwaggerConfig.java
+++ b/src/main/java/kuchat/server/common/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package kuchat.server.config;
+package kuchat.server.common.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Contact;

--- a/src/main/java/kuchat/server/common/exception/KuchatException.java
+++ b/src/main/java/kuchat/server/common/exception/KuchatException.java
@@ -1,0 +1,13 @@
+package kuchat.server.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class KuchatException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    private final String message;
+    private final int code;
+}

--- a/src/main/java/kuchat/server/common/exception/badrequest/BadRequestException.java
+++ b/src/main/java/kuchat/server/common/exception/badrequest/BadRequestException.java
@@ -1,0 +1,12 @@
+package kuchat.server.common.exception.badrequest;
+
+import kuchat.server.common.exception.KuchatException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends KuchatException {
+    public BadRequestException(String message, int code) {
+        super(HttpStatus.BAD_REQUEST, message, code);
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/notfound/NotFoundException.java
+++ b/src/main/java/kuchat/server/common/exception/notfound/NotFoundException.java
@@ -1,0 +1,10 @@
+package kuchat.server.common.exception.notfound;
+
+import kuchat.server.common.exception.KuchatException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends KuchatException {
+    public NotFoundException(String message, int code) {
+        super(HttpStatus.NOT_FOUND, message, code);
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/notfound/NotFoundLanguageException.java
+++ b/src/main/java/kuchat/server/common/exception/notfound/NotFoundLanguageException.java
@@ -1,0 +1,11 @@
+package kuchat.server.common.exception.notfound;
+
+import kuchat.server.common.exception.KuchatException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundLanguageException extends NotFoundException {
+    public NotFoundLanguageException() {
+        super("존재하지 않는 언어입니다.", 3001);
+    }
+
+}

--- a/src/main/java/kuchat/server/common/exception/notfound/NotFoundMemberException.java
+++ b/src/main/java/kuchat/server/common/exception/notfound/NotFoundMemberException.java
@@ -1,0 +1,7 @@
+package kuchat.server.common.exception.notfound;
+
+public class NotFoundMemberException extends NotFoundException{
+    public NotFoundMemberException() {
+        super("존재하지 않는 회원입니다.", 3002);
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/notfound/NotFoundPlatformException.java
+++ b/src/main/java/kuchat/server/common/exception/notfound/NotFoundPlatformException.java
@@ -1,0 +1,7 @@
+package kuchat.server.common.exception.notfound;
+
+public class NotFoundPlatformException extends NotFoundException{
+    public NotFoundPlatformException() {
+        super("존재하지 않는 플랫폼입니다.", 2001);
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/unauthorized/MalformedTokenException.java
+++ b/src/main/java/kuchat/server/common/exception/unauthorized/MalformedTokenException.java
@@ -1,0 +1,7 @@
+package kuchat.server.common.exception.unauthorized;
+
+public class MalformedTokenException extends UnauthorizedException {
+    public MalformedTokenException() {
+        super("토큰이 올바르게 구성되지 않았습니다.", 1001);
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/unauthorized/UnauthorizedException.java
+++ b/src/main/java/kuchat/server/common/exception/unauthorized/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package kuchat.server.common.exception.unauthorized;
+
+import kuchat.server.common.exception.KuchatException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends KuchatException {
+    public UnauthorizedException(String message, int code) {
+        super(HttpStatus.UNAUTHORIZED, message, code);
+    }
+}

--- a/src/main/java/kuchat/server/common/oauth/OAuth2Service.java
+++ b/src/main/java/kuchat/server/common/oauth/OAuth2Service.java
@@ -1,0 +1,56 @@
+package kuchat.server.common.oauth;
+
+import jakarta.servlet.http.HttpSession;
+import kuchat.server.common.oauth.dto.OAuth2Attribute;
+import kuchat.server.domain.enums.Platform;
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+@Service
+public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final MemberRepository memberRepository;
+
+    // 구글이 발급한 엑세스 토큰을 가지고 구글에게 사용자 정보 요청하기
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 엑세스 토큰 가져오기
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId,
+                userNameAttributeName, oAuth2User.getAttributes());
+
+        Platform platform = Platform.getPlatform(registrationId);
+
+        Member member = saveOrUpdate(oAuth2Attribute);
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(member.getRole().getKey())),
+                oAuth2Attribute.getAttributes(),
+                oAuth2Attribute.getUserNameAttributeName()
+        );
+    }
+
+    private Member saveOrUpdate(OAuth2Attribute oAuth2Attribute) {
+        Member member = memberRepository.findByPlatformAndEmail(oAuth2Attribute.getPlatform(), oAuth2Attribute.getEmail())
+                .orElse(oAuth2Attribute.toMember());
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/kuchat/server/common/oauth/OAuth2Service.java
+++ b/src/main/java/kuchat/server/common/oauth/OAuth2Service.java
@@ -1,10 +1,9 @@
 package kuchat.server.common.oauth;
 
-import jakarta.servlet.http.HttpSession;
 import kuchat.server.common.oauth.dto.OAuth2Attribute;
 import kuchat.server.domain.enums.Platform;
 import kuchat.server.domain.member.Member;
-import kuchat.server.domain.member.MemberRepository;
+import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -26,7 +25,7 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
     // 구글이 발급한 엑세스 토큰을 가지고 구글에게 사용자 정보 요청하기
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        // 엑세스 토큰 가져오기
+
         OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
         OAuth2User oAuth2User = delegate.loadUser(userRequest);
         String registrationId = userRequest.getClientRegistration().getRegistrationId();

--- a/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
+++ b/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
@@ -1,0 +1,53 @@
+package kuchat.server.common.oauth.dto;
+
+import kuchat.server.common.exception.notfound.NotFoundPlatformException;
+import kuchat.server.domain.enums.Platform;
+import kuchat.server.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuth2Attribute {
+
+    private Map<String, Object> attributes;
+    private String userNameAttributeName;
+    private String email;
+    private Platform platform;
+
+    @Builder
+    public OAuth2Attribute(Map<String, Object> attributes, String userNameAttributeName, String email) {
+        this.attributes = attributes;
+        this.userNameAttributeName = userNameAttributeName;
+        this.email = email;
+    }
+
+    public static OAuth2Attribute of(String registrationId, String userNameAttributeName,
+                                     Map<String, Object> attributes) {
+        if ("google".equals(registrationId)) {
+            return ofGoogle(userNameAttributeName, attributes);
+        }
+        // 나중엔 네이버도 추가하기
+//        if ("naver".equals(registrationId)){
+//            return ofNaver("id", attributes);
+//        }
+        throw new NotFoundPlatformException();
+    }
+
+    private static OAuth2Attribute ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuth2Attribute.builder()
+                .attributes(attributes)
+                .email((String) attributes.get("email"))
+                .userNameAttributeName(userNameAttributeName)
+                .build();
+    }
+
+    public Member toMember() {
+        return Member.builder()
+                .email(email)
+                .attributeName(userNameAttributeName)
+                .platform(platform)
+                .build();
+    }
+}

--- a/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
+++ b/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
@@ -44,10 +44,6 @@ public class OAuth2Attribute {
     }
 
     public Member toMember() {
-        return Member.builder()
-                .email(email)
-                .attributeName(userNameAttributeName)
-                .platform(platform)
-                .build();
+        return new Member(email, platform, userNameAttributeName);
     }
 }

--- a/src/main/java/kuchat/server/domain/Message.java
+++ b/src/main/java/kuchat/server/domain/Message.java
@@ -1,4 +1,0 @@
-package kuchat.server.domain;
-
-public class Message extends BaseTime {
-}

--- a/src/main/java/kuchat/server/domain/blockMember/BlockMember.java
+++ b/src/main/java/kuchat/server/domain/blockMember/BlockMember.java
@@ -1,6 +1,8 @@
-package kuchat.server.domain;
+package kuchat.server.domain.blockMember;
 
 import jakarta.persistence.*;
+import kuchat.server.domain.BaseTime;
+import kuchat.server.domain.member.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/kuchat/server/domain/enums/Gender.java
+++ b/src/main/java/kuchat/server/domain/enums/Gender.java
@@ -1,5 +1,19 @@
 package kuchat.server.domain.enums;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE("남성"),
+    FEMALE("여성");
+
+    private String value;
+
+    Gender(String value) {
+        this.value = value;
+    }
+
+    public static Gender of(String value) {
+        if (value.equals("남성")) {
+            return MALE;
+        }
+        return FEMALE;
+    }
 }

--- a/src/main/java/kuchat/server/domain/enums/LearnLanguage.java
+++ b/src/main/java/kuchat/server/domain/enums/LearnLanguage.java
@@ -1,13 +1,32 @@
 package kuchat.server.domain.enums;
 
-public enum LearnLanguage {
-    KOREAN,
-    ENGLISH,
-    CHINESE,
-    JAPANESE,
-    RUSSIAN,
-    VIETNAMESE,
-    INDOMALAYAN,        // 인도네시아어
-    MONGOLIAN
+import kuchat.server.common.exception.notfound.NotFoundLanguageException;
+import lombok.Getter;
 
+import java.util.Arrays;
+
+@Getter
+public enum LearnLanguage {
+    KOREAN("한국어"),
+    ENGLISH("영어"),
+    CHINESE("중국어"),
+    JAPANESE("일본어"),
+    RUSSIAN("러시아어"),
+    VIETNAMESE("베트남어"),
+    INDOMALAYAN("인도네시아어"),        // 인도네시아어
+    MONGOLIAN("몽골어");
+
+    private String value;
+
+    LearnLanguage(String value) {
+        this.value = value;
+    }
+
+    public static LearnLanguage of(String value) {
+
+        return Arrays.stream(values())
+                .filter(language -> value.equals(language.getValue()))
+                .findFirst()
+                .orElseThrow(NotFoundLanguageException::new);
+    }
 }

--- a/src/main/java/kuchat/server/domain/enums/Platform.java
+++ b/src/main/java/kuchat/server/domain/enums/Platform.java
@@ -1,0 +1,19 @@
+package kuchat.server.domain.enums;
+
+import kuchat.server.common.exception.notfound.NotFoundPlatformException;
+
+public enum Platform {
+    GOOGLE("google");
+    private String value;
+
+    Platform(String value) {
+        this.value = value;
+    }
+
+    public static Platform getPlatform(String registrationId) {
+        if (registrationId.equals("google")) {
+            return GOOGLE;
+        }
+        throw new NotFoundPlatformException();
+    }
+}

--- a/src/main/java/kuchat/server/domain/enums/Role.java
+++ b/src/main/java/kuchat/server/domain/enums/Role.java
@@ -1,0 +1,15 @@
+package kuchat.server.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    GUEST("ROLE_GUEST", "방문자"),
+    STUDENT("ROLE_STUDENT", "학생"),
+    ADMIN("ROLE_ADMIN", "관리자");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/kuchat/server/domain/enums/SettingLanguage.java
+++ b/src/main/java/kuchat/server/domain/enums/SettingLanguage.java
@@ -1,5 +1,27 @@
 package kuchat.server.domain.enums;
 
+import kuchat.server.common.exception.notfound.NotFoundLanguageException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
 public enum SettingLanguage {
-    ENGLISH, KOREAN
+    ENGLISH("영어"),
+    KOREAN("한국어");
+
+    private String value;
+    SettingLanguage(String value){
+        this.value = value;
+    }
+
+    public static SettingLanguage of(String value) {
+
+        return Arrays.stream(values())
+                .filter(language -> value.equals(language.getValue()))
+                .findFirst()
+                .orElseThrow(NotFoundLanguageException::new);
+    }
+
+
 }

--- a/src/main/java/kuchat/server/domain/friendship/Friendship.java
+++ b/src/main/java/kuchat/server/domain/friendship/Friendship.java
@@ -1,6 +1,8 @@
-package kuchat.server.domain;
+package kuchat.server.domain.friendship;
 
 import jakarta.persistence.*;
+import kuchat.server.domain.BaseTime;
+import kuchat.server.domain.member.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/kuchat/server/domain/jwt/JwtTokenUtil.java
+++ b/src/main/java/kuchat/server/domain/jwt/JwtTokenUtil.java
@@ -1,0 +1,59 @@
+package kuchat.server.domain.jwt;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import kuchat.server.common.exception.unauthorized.MalformedTokenException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenUtil {
+
+    @Value("${secret.jwt-secret-key}")
+    private static String secretKey;
+
+    @Value("${secret.jwt-expired-in}")
+    private static long expireTime;
+
+    public static String generateToken(Long id) {
+        // claims = jwt token에 들어갈 정보, claim에 id를 넣어줘야 회원 식별 가능
+        final Claims claims = Jwts.claims();
+        claims.put("id", id);
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expireTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    // 토큰에서 멤버의 id 추출
+    public static String extractId(String token) {
+        try{
+            return getBody(token)
+                    .get("id")
+                    .toString();
+        } catch (Exception e) {
+            throw new MalformedTokenException();
+        }
+    }
+
+    // 토큰의 만료시간이 지났는지 확인
+    public static boolean isExpired(String token) {
+        Date expiredDate = getBody(token).getExpiration();
+        return expiredDate.before(new Date());
+    }
+
+    private static Claims getBody(String token) {
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJwt(token)
+                .getBody();
+    }
+}

--- a/src/main/java/kuchat/server/domain/jwt/Token.java
+++ b/src/main/java/kuchat/server/domain/jwt/Token.java
@@ -1,0 +1,4 @@
+package kuchat.server.domain.jwt;
+
+public class Token {
+}

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -110,7 +110,6 @@ public class Member extends BaseTime {
         this.studentId = request.getStudentId();
         this.gender = Gender.of(request.getGender());
         this.birthday = request.getBirthday();
-
     }
 
 }

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -8,6 +8,7 @@ import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.blockMember.BlockMember;
 import kuchat.server.domain.enums.*;
 import kuchat.server.domain.friendship.Friendship;
+import kuchat.server.domain.member.dto.SignupRequest;
 import kuchat.server.domain.roomMember.RoomMember;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,8 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static kuchat.server.domain.enums.SettingLanguage.of;
 
 @Entity
 @Table(name = "member")
@@ -89,12 +92,25 @@ public class Member extends BaseTime {
     @Column(nullable = false)
     private String attributeName;
 
-    @Builder
     public Member(String email, Platform platform, String attributeName) {
         this.email = email;
         this.platform = platform;
         this.attributeName = attributeName;
     }
 
+
+    @Builder
+    public Member(SignupRequest request){
+        this.setLanguage = SettingLanguage.of(request.getSetLanguage());
+        this.firstLanguage = LearnLanguage.of(request.getFirstLanguage());
+        this.secondLanguage = LearnLanguage.of(request.getSecondLanguage());
+        this.hometown = request.getHometown();
+        this.name = request.getName();
+        this.department = request.getDepartment();
+        this.studentId = request.getStudentId();
+        this.gender = Gender.of(request.getGender());
+        this.birthday = request.getBirthday();
+
+    }
 
 }

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -1,12 +1,15 @@
-package kuchat.server.domain;
+package kuchat.server.domain.member;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-import kuchat.server.domain.enums.Gender;
-import kuchat.server.domain.enums.LearnLanguage;
-import kuchat.server.domain.enums.SettingLanguage;
+import kuchat.server.domain.BaseTime;
+import kuchat.server.domain.blockMember.BlockMember;
+import kuchat.server.domain.enums.*;
+import kuchat.server.domain.friendship.Friendship;
+import kuchat.server.domain.roomMember.RoomMember;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,19 +27,19 @@ public class Member extends BaseTime {
     @Column(name = "member_id")
     private Long id;
 
-    @Email      // 건국대 이메일로만 제한하는 방법 없나 : @konkuk.ac.kr로 끝나는 이메일만 받습니다.
+    @Email      // 구글 이메일
     @NotEmpty
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     private String name;
 
-    @Column(name = "department", nullable = false)
+    @Column(name = "department")
     private String department;
 
     @Size(min = 9, max = 9)
-    @Column(name = "student_id", nullable = false)
+    @Column(name = "student_id")
     private String studentId;
 
     @Enumerated(EnumType.STRING)
@@ -45,11 +48,11 @@ public class Member extends BaseTime {
     @Size(min = 6, max = 6)
     private String birthday;
 
-    @Column(name = "setting_langugage", nullable = false)
+    @Column(name = "setting_langugage")
     @Enumerated(EnumType.STRING)
     private SettingLanguage setLanguage;
 
-    @Column(name = "learn_language1", nullable = false)
+    @Column(name = "learn_language1")
     @Enumerated(EnumType.STRING)
     private LearnLanguage firstLanguage;
 
@@ -63,7 +66,8 @@ public class Member extends BaseTime {
 
     private String profileImage;
 
-    @OneToMany(mappedBy = "member")      // member:roomMember = 1:다 -> member는 oneToMany     // 얘는 연관관계 종속됨 (주인은 RoomMember 클래스의 member필드)
+    @OneToMany(mappedBy = "member")
+    // member:roomMember = 1:다 -> member는 oneToMany     // 얘는 연관관계 종속됨 (주인은 RoomMember 클래스의 member필드)
     private List<RoomMember> roomMembers = new ArrayList<>();
 
     @OneToMany(mappedBy = "member")
@@ -72,7 +76,25 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "friend")
     private List<Friendship> friendships = new ArrayList<>();
 
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.STUDENT;
+
 //    @OneToMany(mappedBy = "member")
 //    private List<Notification> notifications = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Platform platform;
+
+    @Column(nullable = false)
+    private String attributeName;
+
+    @Builder
+    public Member(String email, Platform platform, String attributeName) {
+        this.email = email;
+        this.platform = platform;
+        this.attributeName = attributeName;
+    }
+
 
 }

--- a/src/main/java/kuchat/server/domain/member/MemberRepository.java
+++ b/src/main/java/kuchat/server/domain/member/MemberRepository.java
@@ -1,0 +1,15 @@
+package kuchat.server.domain.member;
+
+import kuchat.server.domain.enums.Platform;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByPlatformAndEmail(Platform platform, String email);
+}

--- a/src/main/java/kuchat/server/domain/member/controller/MemberController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/MemberController.java
@@ -1,6 +1,5 @@
 package kuchat.server.domain.member.controller;
 
-import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.SignupRequest;
 import kuchat.server.domain.member.dto.SignupResponse;
 import kuchat.server.domain.member.service.MemberService;
@@ -19,9 +18,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/member")
-    public Long signup(@RequestBody SignupRequest signupRequest){
+    public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest signupRequest) {
         log.info("[MemberController - signup request : {}]", signupRequest);
-
-        return memberService.signup(signupRequest);
+        SignupResponse response = memberService.signup(signupRequest);
+        return ResponseEntity.ok(response);
+//        return memberService.signup(signupRequest);
     }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/MemberController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/MemberController.java
@@ -17,11 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+    // 회원가입
     @PostMapping("/member")
     public ResponseEntity<SignupResponse> signup(@RequestBody SignupRequest signupRequest) {
         log.info("[MemberController - signup request : {}]", signupRequest);
+        if(memberService.duplicateStudentId(signupRequest.getStudentId())){
+            System.out.println("[error] 이미 존재하는 학번입니다.");
+        }
+
         SignupResponse response = memberService.signup(signupRequest);
         return ResponseEntity.ok(response);
-//        return memberService.signup(signupRequest);
     }
+
 }

--- a/src/main/java/kuchat/server/domain/member/controller/MemberController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package kuchat.server.domain.member.controller;
+
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.member.dto.SignupRequest;
+import kuchat.server.domain.member.dto.SignupResponse;
+import kuchat.server.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/member")
+    public Long signup(@RequestBody SignupRequest signupRequest){
+        log.info("[MemberController - signup request : {}]", signupRequest);
+
+        return memberService.signup(signupRequest);
+    }
+}

--- a/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
+++ b/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
@@ -1,0 +1,20 @@
+package kuchat.server.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SignupRequest {
+    private String setLanguage;        // SettingLanguage 타입
+    private String firstLanguage;         // LearnLanguage
+    private String secondLanguage;       // LearnLanguage
+    private String hometown;
+    private String name;
+    private String department;
+    private String studentId;
+    private String gender;
+    private String birthday;
+
+
+}

--- a/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
+++ b/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
@@ -15,6 +15,4 @@ public class SignupRequest {
     private String studentId;
     private String gender;
     private String birthday;
-
-
 }

--- a/src/main/java/kuchat/server/domain/member/dto/SignupResponse.java
+++ b/src/main/java/kuchat/server/domain/member/dto/SignupResponse.java
@@ -1,0 +1,16 @@
+package kuchat.server.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignupResponse {
+    private Long id;
+    private Long accessToken;
+    private Long refreshToken;
+
+    public SignupResponse(Long id, Long accessToken, Long refreshToken) {
+        this.id = id;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/kuchat/server/domain/member/dto/SignupResponse.java
+++ b/src/main/java/kuchat/server/domain/member/dto/SignupResponse.java
@@ -5,10 +5,10 @@ import lombok.Getter;
 @Getter
 public class SignupResponse {
     private Long id;
-    private Long accessToken;
-    private Long refreshToken;
+    private String accessToken;
+    private String refreshToken;
 
-    public SignupResponse(Long id, Long accessToken, Long refreshToken) {
+    public SignupResponse(Long id, String accessToken, String refreshToken) {
         this.id = id;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;

--- a/src/main/java/kuchat/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/kuchat/server/domain/member/repository/MemberRepository.java
@@ -12,4 +12,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByPlatformAndEmail(Platform platform, String email);
+
+    Optional<Member> findAllByStudentId(String studentId);
 }

--- a/src/main/java/kuchat/server/domain/member/repository/MemberRepository.java
+++ b/src/main/java/kuchat/server/domain/member/repository/MemberRepository.java
@@ -1,7 +1,7 @@
-package kuchat.server.domain.member;
+package kuchat.server.domain.member.repository;
 
 import kuchat.server.domain.enums.Platform;
-import lombok.extern.slf4j.Slf4j;
+import kuchat.server.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -1,7 +1,9 @@
 package kuchat.server.domain.member.service;
 
+import kuchat.server.domain.jwt.JwtTokenUtil;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.SignupRequest;
+import kuchat.server.domain.member.dto.SignupResponse;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,11 +13,12 @@ import org.springframework.stereotype.Service;
 public class MemberService {
     private final MemberRepository memberRepository;
 
-    public Long signup(SignupRequest signupRequest) {
+    public SignupResponse signup(SignupRequest signupRequest) {
         Member member = memberRepository.save(new Member(signupRequest));
-        // 엑세스 토큰 발급
-        // 리프레시 토큰 발급
-//        return new SignupResponse(member.getId(), );
-        return member.getId();
+        // 엑세스 토큰, 리프레시 토큰 발급
+        String accessToken = JwtTokenUtil.generateToken(member.getId());
+        String refreshToken = JwtTokenUtil.generateToken(member.getId());
+
+        return new SignupResponse(member.getId(), accessToken, refreshToken);
     }
 }

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package kuchat.server.domain.member.service;
 
+import kuchat.server.common.exception.notfound.NotFoundMemberException;
 import kuchat.server.domain.jwt.JwtTokenUtil;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.SignupRequest;
@@ -7,6 +8,8 @@ import kuchat.server.domain.member.dto.SignupResponse;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -20,5 +23,17 @@ public class MemberService {
         String refreshToken = JwtTokenUtil.generateToken(member.getId());
 
         return new SignupResponse(member.getId(), accessToken, refreshToken);
+    }
+
+    public Member getMemberById(String memberId) {
+        Long id = Long.parseLong(memberId);
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new NotFoundMemberException());
+
+    }
+
+    public boolean duplicateStudentId(String studentId) {
+        return memberRepository.findAllByStudentId(studentId)
+                .isPresent();
     }
 }

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -1,0 +1,21 @@
+package kuchat.server.domain.member.service;
+
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.member.dto.SignupRequest;
+import kuchat.server.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Long signup(SignupRequest signupRequest) {
+        Member member = memberRepository.save(new Member(signupRequest));
+        // 엑세스 토큰 발급
+        // 리프레시 토큰 발급
+//        return new SignupResponse(member.getId(), );
+        return member.getId();
+    }
+}

--- a/src/main/java/kuchat/server/domain/message/Message.java
+++ b/src/main/java/kuchat/server/domain/message/Message.java
@@ -1,0 +1,6 @@
+package kuchat.server.domain.message;
+
+import kuchat.server.domain.BaseTime;
+
+public class Message extends BaseTime {
+}

--- a/src/main/java/kuchat/server/domain/room/Room.java
+++ b/src/main/java/kuchat/server/domain/room/Room.java
@@ -1,7 +1,9 @@
-package kuchat.server.domain;
+package kuchat.server.domain.room;
 
-import jakarta.persistence.*;
+import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.enums.Status;
+import jakarta.persistence.*;
+import kuchat.server.domain.roomMember.RoomMember;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/kuchat/server/domain/roomMember/RoomMember.java
+++ b/src/main/java/kuchat/server/domain/roomMember/RoomMember.java
@@ -1,6 +1,9 @@
-package kuchat.server.domain;
+package kuchat.server.domain.roomMember;
 
 import jakarta.persistence.*;
+import kuchat.server.domain.BaseTime;
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.room.Room;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/resources/templates/index.mustache
+++ b/src/main/resources/templates/index.mustache
@@ -1,3 +1,4 @@
 {{>layout/header}}
     <h1>KUchat localhost</h1>
+    <a href="/oauth2/authorization/google" class="btn btn-sm btn-success active" role="button">Google Login</a><br>
 {{>layout/footer}}


### PR DESCRIPTION
## 이슈 번호
Close #3 

## 개요
-  구글 소셜로그인 구현

## 작업사항
- id를 통한 Member 조회 시, 1번 `findById`
- studentId 중복 확인 시, 1번 `findAllByStudentId`

## 주의사항
- feat:JwtTokenFilter, JwtTokenUtil 을 사용한 소셜 로그인 구현
