### PR TITLE
feat/chat : 채팅방 CRUD 구현

### DIFF
--- a/src/main/java/kuchat/server/common/config/SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize                             // 인증, 인가 설정 시 HttpServletRequest 를 사용한다는 의미
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**",
                                 "/swagger-ui/**", "/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/oauth/login", "/member/signup").permitAll()       // 인증 절차 없이 접근 가능해야 하는 페이지 모두 추가하기
+                        .requestMatchers("/oauth/login", "/member/signup", "/ws/message").permitAll()       // 인증 절차 없이 접근 가능해야 하는 페이지 모두 추가하기
                         .anyRequest().authenticated()           // 이 외에 모든 페이지는 인증된 사용자만 접근 가능
                 )
                 .oauth2Login(oauth2Login -> oauth2Login                                      // oauth2 로그인에 관한 다양한 기능 제공

--- a/src/main/java/kuchat/server/common/config/WebSocketConfig.java
+++ b/src/main/java/kuchat/server/common/config/WebSocketConfig.java
@@ -15,7 +15,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(webSocketHandler, "/chat")      // 서버 세팅 후, ws://도메인/chat 에서 테스트할 url 지정
+        registry.addHandler(webSocketHandler, "/ws/message")      // 서버 세팅 후, ws://도메인/ws/message 에서 테스트할 url 지정
                 .setAllowedOrigins("*");        // 웹소켓 정책에 의해 허용 도메인 지정 (* : 모든 도메인 열어주기)
     }
 }

--- a/src/main/java/kuchat/server/common/exception/notfound/ChatroomNotFoundException.java
+++ b/src/main/java/kuchat/server/common/exception/notfound/ChatroomNotFoundException.java
@@ -1,0 +1,7 @@
+package kuchat.server.common.exception.notfound;
+
+public class ChatroomNotFoundException extends NotFoundException{
+    public ChatroomNotFoundException() {
+        super("존재하지 않는 채팅방입니다.", 4001);
+    }
+}

--- a/src/main/java/kuchat/server/common/socket/WebSocketHandler.java
+++ b/src/main/java/kuchat/server/common/socket/WebSocketHandler.java
@@ -1,30 +1,28 @@
 package kuchat.server.common.socket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
-import org.w3c.dom.Text;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class WebSocketHandler extends TextWebSocketHandler {
 
-//    private final ObjectMapper objectMapper;
-//    private final Set<WebSocketSession> sessions = new HashSet<>();         // 현재 연결된 세션들
-//    private final Map<Long, Set<WebSocketSession>> chatroomSessions = new HashMap<>();          //
+    private final ObjectMapper objectMapper;
+
+    private final Set<WebSocketSession> sessions = new HashSet<>();         // 현재 연결된 세션들
+    private final Map<Long, Set<WebSocketSession>> chatroomSessions = new HashMap<>();          // chatroom id - session 매핑
 //
 //    // CLIENT 변수에 session을 저장
 //    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS
@@ -44,7 +42,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
 
     // 웹소켓 서버가 사용자의 메세지를 받을 때 동작을 구현
     @Override
-    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception{
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
 //        String id = session.getId();        // 메세지를 보낸 사람의 세션 아이디
         String text = message.getPayload();
         log.info("[handleTextMessage] 메시지의 payload : {}", text);
@@ -63,4 +61,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
 //        });
     }
 
+    public boolean addSession(WebSocketSession session) {
+        return sessions.add(session);
+    }
 }

--- a/src/main/java/kuchat/server/common/socket/WebSocketHandler.java
+++ b/src/main/java/kuchat/server/common/socket/WebSocketHandler.java
@@ -1,46 +1,66 @@
 package kuchat.server.common.socket;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.w3c.dom.Text;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Slf4j
+@RequiredArgsConstructor
 @Component
 public class WebSocketHandler extends TextWebSocketHandler {
 
-    // CLIENT 변수에 session을 저장
-    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS
-            = new ConcurrentHashMap<String, WebSocketSession>();
-
-    // 사용자가 웹소켓 서버에 접속할 때 동작을 구현
-    @Override
-    public void afterConnectionEstablished(WebSocketSession session){
-        CLIENTS.put(session.getId(), session);      // 접속 시 생성되는 session을 CLIENT에 담는다.
-    }
-
-    // 사용자의 웹소켓 서버 접속이 끝났을 때 동작을 구현
-    @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status){
-        CLIENTS.remove(session.getId());        // 저장된 세션을 제거
-    }
+//    private final ObjectMapper objectMapper;
+//    private final Set<WebSocketSession> sessions = new HashSet<>();         // 현재 연결된 세션들
+//    private final Map<Long, Set<WebSocketSession>> chatroomSessions = new HashMap<>();          //
+//
+//    // CLIENT 변수에 session을 저장
+//    private static final ConcurrentHashMap<String, WebSocketSession> CLIENTS
+//            = new ConcurrentHashMap<String, WebSocketSession>();
+//
+//    // 사용자가 웹소켓 서버에 접속할 때 동작을 구현
+//    @Override
+//    public void afterConnectionEstablished(WebSocketSession session){
+//        CLIENTS.put(session.getId(), session);      // 접속 시 생성되는 session을 CLIENT에 담는다.
+//    }
+//
+//    // 사용자의 웹소켓 서버 접속이 끝났을 때 동작을 구현
+//    @Override
+//    public void afterConnectionClosed(WebSocketSession session, CloseStatus status){
+//        CLIENTS.remove(session.getId());        // 저장된 세션을 제거
+//    }
 
     // 웹소켓 서버가 사용자의 메세지를 받을 때 동작을 구현
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception{
-        String id = session.getId();        // 메세지를 보낸 사람의 세션 아이디
-        CLIENTS.entrySet().forEach(arg -> {
-            if(!arg.getKey().equals(id)){       // 보낸 사람 제외 모든 사용자에게 메세지 전송
-                try{
-                    arg.getValue().sendMessage(message);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
+//        String id = session.getId();        // 메세지를 보낸 사람의 세션 아이디
+        String text = message.getPayload();
+        log.info("[handleTextMessage] 메시지의 payload : {}", text);
+
+        TextMessage textMessage = new TextMessage("채팅 서버에 입장하였습니다.");
+        session.sendMessage(textMessage);
+
+//        CLIENTS.entrySet().forEach(arg -> {
+//            if(!arg.getKey().equals(id)){       // 보낸 사람 제외 모든 사용자에게 메세지 전송
+//                try{
+//                    arg.getValue().sendMessage(message);
+//                } catch (IOException e) {
+//                    throw new RuntimeException(e);
+//                }
+//            }
+//        });
     }
 
 }

--- a/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
+++ b/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
@@ -1,14 +1,14 @@
 package kuchat.server.domain.chatroom;
 
-import kuchat.server.domain.BaseTime;
-import kuchat.server.domain.enums.Status;
 import jakarta.persistence.*;
-import kuchat.server.domain.roomMember.RoomMember;
+import kuchat.server.domain.BaseTime;
+import kuchat.server.domain.chatroomMember.ChatroomMember;
+import kuchat.server.domain.enums.Status;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
 
 @Entity
 @Table(name = "chatroom")
@@ -27,8 +27,19 @@ public class Chatroom extends BaseTime {
     private Status status;
 
     @OneToMany(mappedBy = "chatroom")
-    private List<RoomMember> roomMember = new ArrayList<>();
+    private HashSet<ChatroomMember> chatroomMember = new HashSet<>();       // 채팅방에 속한 클라이언트들 리스트
 
 //    @OneToMany(mappedBy = "room")
 //    private List<Message> messages = new ArrayList<>();
+
+
+    @Builder
+    public Chatroom(String name) {
+        this.name = name;
+        status = Status.ACTIVE;
+    }
+
+    public void updateName(String newName) {
+        this.name = newName;
+    }
 }

--- a/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
+++ b/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
@@ -1,4 +1,4 @@
-package kuchat.server.domain.room;
+package kuchat.server.domain.chatroom;
 
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.enums.Status;
@@ -11,10 +11,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "room")
+@Table(name = "chatroom")
 @Getter
 @NoArgsConstructor
-public class Room extends BaseTime {
+public class Chatroom extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,7 +26,7 @@ public class Room extends BaseTime {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @OneToMany(mappedBy = "room")
+    @OneToMany(mappedBy = "chatroom")
     private List<RoomMember> roomMember = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "room")

--- a/src/main/java/kuchat/server/domain/chatroom/controller/ChatroomController.java
+++ b/src/main/java/kuchat/server/domain/chatroom/controller/ChatroomController.java
@@ -1,0 +1,15 @@
+package kuchat.server.domain.chatroom.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Room", description = "채팅방")
+@RequiredArgsConstructor
+@RequestMapping("/chatroom")
+@RestController
+public class ChatroomController {
+}

--- a/src/main/java/kuchat/server/domain/chatroom/controller/ChatroomController.java
+++ b/src/main/java/kuchat/server/domain/chatroom/controller/ChatroomController.java
@@ -1,15 +1,54 @@
 package kuchat.server.domain.chatroom.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import kuchat.server.domain.chatroom.dto.ChatroomResponse;
+import kuchat.server.domain.chatroom.dto.CreateChatroomRequest;
+import kuchat.server.domain.chatroom.dto.FindChatroomsResponse;
+import kuchat.server.domain.chatroom.service.ChatroomService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
-@Tag(name = "Room", description = "채팅방")
+@Tag(name = "Chatroom", description = "채팅방")
 @RequiredArgsConstructor
 @RequestMapping("/chatroom")
 @RestController
 public class ChatroomController {
+
+    private final ChatroomService chatroomService;
+
+    @Operation(summary = "채팅방 생성")
+    @PostMapping("")
+    public ResponseEntity<ChatroomResponse> createChatroom(@RequestBody CreateChatroomRequest request) {
+        ChatroomResponse response = chatroomService.createChatroom(request);
+        log.info("[createChatroom] 생성된 채팅방 id : {}", response.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "채팅방 이름 혹은 구성원 이름으로 채팅방 목록 조회")
+    @GetMapping("")
+    public ResponseEntity<FindChatroomsResponse> search(@RequestParam String name) {
+        log.info("[findChatrooms] 검색어 : {}", name);
+        FindChatroomsResponse response = chatroomService.findChatrooms(name);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "채팅방 이름 변경 (단체 톡방만 가능)")
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateName(@PathVariable Long id,
+                                           @RequestBody UpdateChatroomRequest request) {
+        chatroomService.updateName(id, request.getNewName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "채팅방 제거")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ChatroomResponse> delete(@PathVariable Long id) {
+        ChatroomResponse response = chatroomService.delete(id);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/kuchat/server/domain/chatroom/controller/UpdateChatroomRequest.java
+++ b/src/main/java/kuchat/server/domain/chatroom/controller/UpdateChatroomRequest.java
@@ -1,0 +1,10 @@
+package kuchat.server.domain.chatroom.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateChatroomRequest {
+    private String newName;
+}

--- a/src/main/java/kuchat/server/domain/chatroom/dto/ChatroomResponse.java
+++ b/src/main/java/kuchat/server/domain/chatroom/dto/ChatroomResponse.java
@@ -1,0 +1,10 @@
+package kuchat.server.domain.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatroomResponse {
+    private Long id;
+}

--- a/src/main/java/kuchat/server/domain/chatroom/dto/CreateChatroomRequest.java
+++ b/src/main/java/kuchat/server/domain/chatroom/dto/CreateChatroomRequest.java
@@ -1,0 +1,12 @@
+package kuchat.server.domain.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateChatroomRequest {
+    private String name;
+}

--- a/src/main/java/kuchat/server/domain/chatroom/dto/FindChatroomResponse.java
+++ b/src/main/java/kuchat/server/domain/chatroom/dto/FindChatroomResponse.java
@@ -1,0 +1,14 @@
+package kuchat.server.domain.chatroom.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindChatroomResponse {
+    private Long id;
+    private String name;
+
+    public FindChatroomResponse(Long id, String name){
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/kuchat/server/domain/chatroom/dto/FindChatroomsResponse.java
+++ b/src/main/java/kuchat/server/domain/chatroom/dto/FindChatroomsResponse.java
@@ -1,0 +1,12 @@
+package kuchat.server.domain.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FindChatroomsResponse {
+    private List<FindChatroomResponse> chatrooms;
+}

--- a/src/main/java/kuchat/server/domain/chatroom/dto/JoinMemberRequest.java
+++ b/src/main/java/kuchat/server/domain/chatroom/dto/JoinMemberRequest.java
@@ -1,0 +1,12 @@
+package kuchat.server.domain.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class JoinMemberRequest {
+    private List<Long> joinMembers;
+}

--- a/src/main/java/kuchat/server/domain/chatroom/repository/ChatroomRepository.java
+++ b/src/main/java/kuchat/server/domain/chatroom/repository/ChatroomRepository.java
@@ -1,0 +1,4 @@
+package kuchat.server.domain.chatroom.repository;
+
+public interface ChatroomRepository {
+}

--- a/src/main/java/kuchat/server/domain/chatroom/repository/ChatroomRepository.java
+++ b/src/main/java/kuchat/server/domain/chatroom/repository/ChatroomRepository.java
@@ -1,4 +1,13 @@
 package kuchat.server.domain.chatroom.repository;
 
-public interface ChatroomRepository {
+import kuchat.server.domain.chatroom.Chatroom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ChatroomRepository extends JpaRepository<Chatroom, Long> {
+
+    @Query("select c from Chatroom c where c.name = :name")
+    List<Chatroom> findByName(String name);
 }

--- a/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
+++ b/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
@@ -1,0 +1,4 @@
+package kuchat.server.domain.chatroom.service;
+
+public class ChatroomService {
+}

--- a/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
+++ b/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
@@ -1,4 +1,91 @@
 package kuchat.server.domain.chatroom.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kuchat.server.common.exception.notfound.NotFoundMemberException;
+import kuchat.server.common.socket.WebSocketHandler;
+import kuchat.server.domain.chatroom.Chatroom;
+import kuchat.server.domain.chatroom.dto.ChatroomResponse;
+import kuchat.server.domain.chatroom.dto.CreateChatroomRequest;
+import kuchat.server.domain.chatroom.dto.FindChatroomResponse;
+import kuchat.server.domain.chatroom.dto.FindChatroomsResponse;
+import kuchat.server.domain.chatroom.repository.ChatroomRepository;
+import kuchat.server.domain.enums.MessageType;
+import kuchat.server.domain.message.dto.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
 public class ChatroomService {
+
+    private final ChatroomRepository chatroomRepository;
+    private final WebSocketHandler webSocketHandler;
+    private final ObjectMapper objectMapper;
+
+    public void handlerActions(WebSocketSession session, ChatMessage chatMessage) {
+        if (chatMessage.getMessageType() == MessageType.ENTER) {
+            if (webSocketHandler.addSession(session)) {
+                chatMessage.setText("👋🏻 " + chatMessage.getSender() + " 님이 입장했습니다.");
+            }
+        }
+        sendMessage(session, chatMessage);
+    }
+
+    //    @Transactional
+    private <T> void sendMessage(WebSocketSession session, ChatMessage chatMessage) {
+//        try{
+//            session.sendMessage(chatMessage);
+
+//        } catch (IOException e){
+
+//        }
+    }
+
+    @Transactional
+    public ChatroomResponse createChatroom(CreateChatroomRequest request) {
+        Chatroom chatroom = chatroomRepository.save(
+                Chatroom.builder()
+                        .name(request.getName())
+                        .build());
+        return new ChatroomResponse(chatroom.getId());
+    }
+
+    public FindChatroomsResponse findChatrooms(String name) {
+        List<Chatroom> chatrooms = chatroomRepository.findByName(name);
+        List<FindChatroomResponse> findChatroomRespons = chatrooms.stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+        return new FindChatroomsResponse(findChatroomRespons);
+    }
+
+
+    private FindChatroomResponse toResponse(Chatroom chatroom) {
+        return new FindChatroomResponse(chatroom.getId(), chatroom.getName());
+    }
+
+    @Transactional
+    public ChatroomResponse delete(Long id) {
+        Chatroom chatroom = chatroomRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+        ChatroomResponse response = new ChatroomResponse(chatroom.getId());
+        chatroomRepository.delete(chatroom);
+        return response;
+    }
+
+    @Transactional
+    public void updateName(Long id, String newName) {
+
+        Chatroom chatroom = chatroomRepository.findById(id)
+                .orElseThrow(NotFoundMemberException::new);
+        chatroom.updateName(newName);
+    }
 }

--- a/src/main/java/kuchat/server/domain/chatroomMember/ChatroomMember.java
+++ b/src/main/java/kuchat/server/domain/chatroomMember/ChatroomMember.java
@@ -1,4 +1,4 @@
-package kuchat.server.domain.roomMember;
+package kuchat.server.domain.chatroomMember;
 
 import jakarta.persistence.*;
 import kuchat.server.domain.BaseTime;
@@ -11,19 +11,18 @@ import lombok.NoArgsConstructor;
 @Table(name = "room_member")
 @Getter
 @NoArgsConstructor
-
-public class RoomMember extends BaseTime {
+public class ChatroomMember extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "room_member_id", nullable = false)
-    private Long roomId;
+    @Column(name = "chatroom_member_id", nullable = false)
+    private Long id;
 
     @ManyToOne              // member : roomMember = 1:다 -> roomMember에는 ManyToOne
     @JoinColumn(name = "member_id")         // fk 이름이 member_id가 된다. 얘가 연관관계 주인
     private Member member;
 
     @ManyToOne
-    @JoinColumn(name = "room_id")
+    @JoinColumn(name = "chatroom_id")
     private Chatroom chatroom;
 }

--- a/src/main/java/kuchat/server/domain/enums/MessageType.java
+++ b/src/main/java/kuchat/server/domain/enums/MessageType.java
@@ -1,0 +1,5 @@
+package kuchat.server.domain.enums;
+
+public enum MessageType {
+    ENTER, TALK, EXIT;
+}

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -11,13 +11,16 @@ import kuchat.server.domain.blockMember.BlockMember;
 import kuchat.server.domain.enums.*;
 import kuchat.server.domain.friendship.Friendship;
 import kuchat.server.domain.member.dto.SignupRequest;
-import kuchat.server.domain.roomMember.RoomMember;
+import kuchat.server.domain.chatroomMember.ChatroomMember;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.web.socket.WebSocketSession;
 
+import java.net.http.WebSocket;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 @Entity
@@ -72,15 +75,16 @@ public class Member extends BaseTime {
 
     private String profileImage;
 
+
     @OneToMany(mappedBy = "member")
     // member:roomMember = 1:다 -> member는 oneToMany     // 얘는 연관관계 종속됨 (주인은 RoomMember 클래스의 member필드)
-    private List<RoomMember> roomMembers = new ArrayList<>();
+    private List<ChatroomMember> chatroomMembers = new ArrayList<>();           // 채팅방-사용자 테이블과 member 테이블을 이어주는 칼럼
 
     @OneToMany(mappedBy = "member")
-    private List<BlockMember> blockMembers = new ArrayList<>();
+    private List<BlockMember> blockMembers = new ArrayList<>();         // 차단한 사람 목록
 
     @OneToMany(mappedBy = "friend")
-    private List<Friendship> friendships = new ArrayList<>();
+    private List<Friendship> friendships = new ArrayList<>();        // 친구목록
 
     @Enumerated(EnumType.STRING)
     private Role role;

--- a/src/main/java/kuchat/server/domain/message/Message.java
+++ b/src/main/java/kuchat/server/domain/message/Message.java
@@ -1,6 +1,30 @@
 package kuchat.server.domain.message;
 
+import jakarta.persistence.*;
 import kuchat.server.domain.BaseTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@Entity
+@Table(name = "message")
+@Getter
+@NoArgsConstructor
+@ToString
 public class Message extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long id;
+    // 메시지는 하나의 채팅방 안에서만 고유하도록 설정
+
+    @Column(name = "room_id")
+    private Long roomId;
+
+    @Column(name = "parent_id")
+    private Long parentMessageId;
+
+    @Column(name = "sender_id")
+    private Long sender;
 }

--- a/src/main/java/kuchat/server/domain/message/controller/MessageController.java
+++ b/src/main/java/kuchat/server/domain/message/controller/MessageController.java
@@ -1,0 +1,16 @@
+package kuchat.server.domain.message.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Message", description = "메시지")
+@RequiredArgsConstructor
+@RequestMapping("/message")
+@RestController
+public class MessageController {
+
+}

--- a/src/main/java/kuchat/server/domain/message/controller/MessageController.java
+++ b/src/main/java/kuchat/server/domain/message/controller/MessageController.java
@@ -3,6 +3,8 @@ package kuchat.server.domain.message.controller;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,5 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/message")
 @RestController
 public class MessageController {
+
 
 }

--- a/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
@@ -1,0 +1,16 @@
+package kuchat.server.domain.message.dto;
+
+import kuchat.server.domain.enums.MessageType;
+import lombok.*;
+
+
+@Getter
+@AllArgsConstructor
+@ToString
+public class ChatMessage {
+    private MessageType messageType;
+    private Long roomId;
+    private Long sender;
+    @Setter
+    private String text;
+}

--- a/src/main/java/kuchat/server/domain/message/dto/TextMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/TextMessage.java
@@ -1,0 +1,4 @@
+package kuchat.server.domain.message.dto;
+
+public class TextMessage {
+}

--- a/src/main/java/kuchat/server/domain/message/dto/TextMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/TextMessage.java
@@ -1,4 +1,0 @@
-package kuchat.server.domain.message.dto;
-
-public class TextMessage {
-}

--- a/src/main/java/kuchat/server/domain/message/repository/MessageRepository.java
+++ b/src/main/java/kuchat/server/domain/message/repository/MessageRepository.java
@@ -1,0 +1,9 @@
+package kuchat.server.domain.message.repository;
+
+import kuchat.server.domain.message.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageRepository extends JpaRepository<Message, Long> {
+}

--- a/src/main/java/kuchat/server/domain/message/service/MessageService.java
+++ b/src/main/java/kuchat/server/domain/message/service/MessageService.java
@@ -1,0 +1,13 @@
+package kuchat.server.domain.message.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MessageService {
+}

--- a/src/main/java/kuchat/server/domain/roomMember/RoomMember.java
+++ b/src/main/java/kuchat/server/domain/roomMember/RoomMember.java
@@ -3,7 +3,7 @@ package kuchat.server.domain.roomMember;
 import jakarta.persistence.*;
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.member.Member;
-import kuchat.server.domain.room.Room;
+import kuchat.server.domain.chatroom.Chatroom;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,5 +25,5 @@ public class RoomMember extends BaseTime {
 
     @ManyToOne
     @JoinColumn(name = "room_id")
-    private Room room;
+    private Chatroom chatroom;
 }


### PR DESCRIPTION
## 이슈번호
Close #5 

## 개요
- 채팅방(Chatroom) CRUD 구현

## 작업사항
- 채팅방 생성 시 1번 : `save`
- 채팅방 이름 검색 시 1번 : `findByName`
- 채팅방 이름 변경 시 2번 : `findById`-> 트랜잭션 종료 시 엔티티 변경사항 자동 반영
- 채팅방 제거 시 2번 : `findById` -> `delete`
