### PR TITLE
[Closes #9] 레디스 도입하여 웹소켓 세션 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'		// mysql8.0.35
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/src/main/java/kuchat/server/common/config/BaseTimeConfig.java
+++ b/src/main/java/kuchat/server/common/config/BaseTimeConfig.java
@@ -1,0 +1,16 @@
+package kuchat.server.common.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.TimeZone;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+    @PostConstruct
+    public void setSeoulTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/kuchat/server/common/config/RedisConfig.java
+++ b/src/main/java/kuchat/server/common/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package kuchat.server.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private String port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    // redis 와의 연결 정보 설정
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, Integer.parseInt(port));
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    // Redis 데이터를 저장, 조회하는데 사용되는 redisTemplate 객체 생성
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/kuchat/server/common/config/SecurityConfig.java
+++ b/src/main/java/kuchat/server/common/config/SecurityConfig.java
@@ -12,9 +12,9 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity          // spring security 기능을 활성화시키는 어노테이션
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final OAuth2Service oAuth2Service;

--- a/src/main/java/kuchat/server/common/config/WebSocketConfig.java
+++ b/src/main/java/kuchat/server/common/config/WebSocketConfig.java
@@ -1,6 +1,6 @@
 package kuchat.server.common.config;
 
-import kuchat.server.common.socket.WebSocketHandler;
+import kuchat.server.domain.message.service.WebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;

--- a/src/main/java/kuchat/server/common/config/WebSocketConfig.java
+++ b/src/main/java/kuchat/server/common/config/WebSocketConfig.java
@@ -7,9 +7,9 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSocket
-@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
     private final WebSocketHandler webSocketHandler;
 

--- a/src/main/java/kuchat/server/common/exception/BaseResponse.java
+++ b/src/main/java/kuchat/server/common/exception/BaseResponse.java
@@ -31,7 +31,7 @@ public enum BaseResponse {
     MALFORMED_CHATROOM_ID(4003, HttpStatus.BAD_REQUEST, "uri의 채팅방 id가 올바르지 않습니다."),
     DUPLICATED_JOIN(4004, HttpStatus.BAD_REQUEST, "이미 참여하고 있는 회원은 초대할 수 없습니다."),
 
-    //- 5000번대 : 메시지(message) 관련 코드
+    //- 5000번대 : 메시지(message)/소켓 관련 코드
     MESSAGE_SEND_SUCCESS(5000, HttpStatus.OK, "메세지 전송 성공"),
     WEBSOCKET_CONNECTION_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "웹소켓 서버 접속에 실패했습니다."),
     WEBSOCKET_CLOSE_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "웹소켓 서버와의 연결 종료에 실패했습니다."),
@@ -40,6 +40,8 @@ public enum BaseResponse {
     MESSAGE_SEND_FAIL(5004, HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송해 실패했습니다."),
     NOT_FOUND_MESSAGE(5005, HttpStatus.NOT_FOUND, "존재하지 않는 메세지입니다."),
     MESSAGE_LENGTH_UNMATCH(5006, HttpStatus.BAD_REQUEST, "메세지의 payload 길이가 일치하지 않습니다."),
+    NOT_FOUND_SESSION(5007, HttpStatus.NOT_FOUND, "사용자의 웹소켓 세션이 존재하지 않습니다. 다시 연결을 시도해주세요."),
+    WEBSOCKET_DISCONNECT(5008, HttpStatus.INTERNAL_SERVER_ERROR, "웹소켓 서버와의 연결이 끊겼습니다. 다시 연결을 시도해주세요."),
 
     //- 6000번대 : 친구 관련 코드
 

--- a/src/main/java/kuchat/server/common/exception/BaseResponse.java
+++ b/src/main/java/kuchat/server/common/exception/BaseResponse.java
@@ -48,7 +48,8 @@ public enum BaseResponse {
 
     //- 8000번대 : DB 관련 코드
     DB_SUCCESS(8000, HttpStatus.ACCEPTED,"DB에 성공적으로 반영되었습니다."),
-    DB_SAVE_FAIL(8001, HttpStatus.INTERNAL_SERVER_ERROR, "DB 저장에 실패했습니다.");
+    DB_SAVE_FAIL(8001, HttpStatus.INTERNAL_SERVER_ERROR, "DB 저장에 실패했습니다."),
+    REDIS_FIND_FAIL(8002, HttpStatus.INTERNAL_SERVER_ERROR, "레디스에서 정보를 조회하는데 실패했습니다.");
 
     private int code;
     private HttpStatus httpStatus;

--- a/src/main/java/kuchat/server/common/exception/BaseResponse.java
+++ b/src/main/java/kuchat/server/common/exception/BaseResponse.java
@@ -33,10 +33,13 @@ public enum BaseResponse {
 
     //- 5000번대 : 메시지(message) 관련 코드
     MESSAGE_SEND_SUCCESS(5000, HttpStatus.OK, "메세지 전송 성공"),
-    CONVERT_TO_JSON_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "메시지 객체를 json 형태로 바꾸는데 실패했습니다"),
-    CONVERT_TO_OBJECT_FAIL(5002, HttpStatus.INTERNAL_SERVER_ERROR, "json을 메세지 객체 형태로 바꾸는데 실패했습니다"),
-    MESSAGE_SEND_FAIL(5003, HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송해 실패했습니다."),
-    NOT_FOUND_MESSAGE(5004, HttpStatus.NOT_FOUND, "존재하지 않는 메세지입니다."),
+    WEBSOCKET_CONNECTION_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "웹소켓 서버 접속에 실패했습니다."),
+    WEBSOCKET_CLOSE_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "웹소켓 서버와의 연결 종료에 실패했습니다."),
+    CONVERT_TO_JSON_FAIL(5002, HttpStatus.INTERNAL_SERVER_ERROR, "메시지 객체를 json 형태로 바꾸는데 실패했습니다"),
+    CONVERT_TO_OBJECT_FAIL(5003, HttpStatus.INTERNAL_SERVER_ERROR, "json을 메세지 객체 형태로 바꾸는데 실패했습니다"),
+    MESSAGE_SEND_FAIL(5004, HttpStatus.INTERNAL_SERVER_ERROR, "메시지 전송해 실패했습니다."),
+    NOT_FOUND_MESSAGE(5005, HttpStatus.NOT_FOUND, "존재하지 않는 메세지입니다."),
+    MESSAGE_LENGTH_UNMATCH(5006, HttpStatus.BAD_REQUEST, "메세지의 payload 길이가 일치하지 않습니다."),
 
     //- 6000번대 : 친구 관련 코드
 

--- a/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
+++ b/src/main/java/kuchat/server/common/oauth/dto/OAuth2Attribute.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
-import java.util.UUID;
 
 import static kuchat.server.common.exception.BaseResponse.NOT_FOUND_PLATFORM;
 
@@ -41,6 +40,7 @@ public class OAuth2Attribute {
                                      Map<String, Object> attributes) {
         log.info("[of] platform = {}, attributeKey = {}, attributes = {}",
                 platform, attributeKey, attributes.toString());
+        // platform = GOOGLE, attributeKey = sub, attributes = {sub=구글에서 부여한 id, name=lys, given_name=lys, picture=구글프로필url, email=구글메일, email_verified=true}
         if (platform == Platform.GOOGLE) {
             return ofGoogle(attributeKey, attributes);
         }
@@ -59,9 +59,10 @@ public class OAuth2Attribute {
 
     public Member toMember(Platform platform, String attributeName, OAuth2UserInfo oAuth2UserInfo) {
         return Member.builder()
-                .email(UUID.randomUUID() + "@socialUser.com")
+                .email(oAuth2UserInfo.getEmail())
                 .platform(platform)
                 .attributeName(attributeName)
+                .profileImage(oAuth2UserInfo.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/kuchat/server/common/oauth/service/OAuth2Service.java
+++ b/src/main/java/kuchat/server/common/oauth/service/OAuth2Service.java
@@ -60,6 +60,7 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
     private Member saveOrUpdate(OAuth2Attribute oAuth2Attribute) {
         Platform platform = oAuth2Attribute.getPlatform();
         String attributeValue = oAuth2Attribute.getAttributeValue();
+//        String email = oAuth2Attribute.getOAuth2UserInfo().get
 
         Optional<Member> optionalMember = memberRepository.findByPlatformAndAttributeName(platform, attributeValue);
 

--- a/src/main/java/kuchat/server/common/oauth/userInfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/kuchat/server/common/oauth/userInfo/GoogleOAuth2UserInfo.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public class GoogleOAuth2UserInfo extends OAuth2UserInfo{
 
     public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        // attributes = {sub=구글에서 부여한 id, name=lys, given_name=lys, picture=구글프로필url, email=구글메일, email_verified=true}
         super(attributes);
     }
 
@@ -14,12 +15,12 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo{
     }
 
     @Override
-    public String getNickname() {
-        return (String) attributes.get("name");
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
     }
 
     @Override
-    public String getImageUrl() {
-        return (String) attributes.get("picture");
+    public String getEmail(){
+        return (String) attributes.get("email");
     }
 }

--- a/src/main/java/kuchat/server/common/oauth/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/kuchat/server/common/oauth/userInfo/OAuth2UserInfo.java
@@ -1,7 +1,10 @@
 package kuchat.server.common.oauth.userInfo;
 
+import lombok.ToString;
+
 import java.util.Map;
 
+@ToString
 public abstract class OAuth2UserInfo {
     protected Map<String, Object> attributes;
 
@@ -11,7 +14,7 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getId(); //소셜 식별 값 : 구글 - "sub", 카카오 - "id", 네이버 - "id"
 
-    public abstract String getNickname();
+    public abstract String getEmail();
 
     public abstract String getImageUrl();
 }

--- a/src/main/java/kuchat/server/common/redis/RedisController.java
+++ b/src/main/java/kuchat/server/common/redis/RedisController.java
@@ -1,0 +1,63 @@
+package kuchat.server.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class RedisController {
+
+    private final RedisService redisService;
+
+    // 1. ValueOperations
+    //    "refreshToken: {memberId}" : "{refreshToken}"
+
+    // 2. ValueOperations
+    //    "session: {memberId}" : "{sessionId}"
+
+    // 3. HashOperations (한 채팅방에 대한 정보)
+    //    "chatroomId : {id}"
+    //      - "{memberId}" : "{세션 id}"
+    //      - "{memberId}" : "{세션 id}"
+
+
+    public void putRefreshToken(Long memberId, String refreshToken) {
+        redisService.putValueOp("refreshToken: " + memberId, refreshToken);
+    }
+
+    public boolean putMemberSession(Long memberId, String sessionId) {
+        redisService.putValueOp("session: " + memberId, sessionId);
+        return true;
+    }
+
+    public String getRefreshToken(Long memberId) {
+        return redisService.getValueOp("refreshToken: " + memberId);
+    }
+
+    public String getMemberSession(Long memberId) {
+        return redisService.getValueOp("session: " + memberId);
+    }
+
+    public void putChatroomSession(Long chatroomId, Long memberId, String sessionId) {
+        redisService.putHashOp("chatroom: " + chatroomId, memberId, sessionId);
+    }
+
+    public void putChatroomSessions(Long chatroomId, Map<Long, String> map){
+        redisService.putHashOps("chatroom: " + chatroomId, map);
+    }
+
+    // 한 채팅방에 있는 모든 <member id, session id> 쌍을 반환
+    public Map<Long, String> getChatroomSessions(Long chatroomId) {
+        return redisService.getHashOpMap("chatroom: " + chatroomId);
+    }
+
+    public boolean deleteChatroomSession(Long chatroomId, Long memberId) {
+        redisService.deleteHashOp("chatroom: " + chatroomId, memberId.toString());
+        return true;
+    }
+
+}

--- a/src/main/java/kuchat/server/common/redis/RedisService.java
+++ b/src/main/java/kuchat/server/common/redis/RedisService.java
@@ -1,0 +1,89 @@
+package kuchat.server.common.redis;
+
+import kuchat.server.common.exception.KuchatException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static kuchat.server.common.exception.BaseResponse.REDIS_FIND_FAIL;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+//@Component
+@Service
+public class RedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // 1. ValueOperations : key - value
+    @Transactional
+    public void putValueOp(String key, String value) {
+        log.info("[putValueOp] key = {}, value = {}", key, value);
+        ValueOperations<String, Object> valueOps = redisTemplate.opsForValue();
+        valueOps.set(key, value);
+    }
+
+    public String getValueOp(String key) {
+        String value = (String) redisTemplate.opsForValue().get(key);
+        log.info("[getValueOp] key = {}, value = {}", key, value);
+        return value;
+    }
+
+    @Transactional
+    public boolean deleteValueOp(String key) {
+        log.info("[deleteValueOp] 제거하는 key = {}", key);
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+
+    // 2. HashOperations : key - hash key - value
+    @Transactional
+    public void putHashOp(String key, Long hashKey, String value) {
+        log.info("[putHashOp] key = {}, hash key = {}, value = {}", key, hashKey.toString(), value);
+        HashOperations<String, Long, String> hashOps = redisTemplate.opsForHash();
+        hashOps.put(key, hashKey, value);
+    }
+
+    @Transactional
+    public void putHashOps(String key, Map<Long, String> data) {
+        log.info("[putHashOps] key = {}, Map <hash key, value> = {}", key, data.toString());
+        HashOperations<String, Long, String> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    public String getHashOp(String key, Long hashKey) {
+        String value = (String) redisTemplate.opsForHash().get(key, hashKey);
+        log.info("[getHashOp] 조회하는 key = {}, hashKey = {}, value = {}", key, hashKey, value);
+        return value;
+    }
+
+    public Map<Long, String> getHashOpMap(String key) {
+        Map<Object, Object> rawMap = redisTemplate.opsForHash().entries(key);
+        Map<Long, String> result = new HashMap<>();
+        for (Map.Entry<Object, Object> entry : rawMap.entrySet()) {
+            try {
+                Long keyAsLong = (Long) entry.getKey();
+                String valueAsString = (String) entry.getValue();
+                result.put(keyAsLong, valueAsString);
+            } catch (Exception e) {
+                throw new KuchatException(REDIS_FIND_FAIL);
+            }
+        }
+        return result;
+    }
+
+    @Transactional
+    public void deleteHashOp(String key, String hashKey) {
+        log.info("[deleteHashOp] 제거하는 key = {}, hashKey = {}", key, hashKey);
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+}

--- a/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
+++ b/src/main/java/kuchat/server/domain/chatroom/Chatroom.java
@@ -6,17 +6,14 @@ import kuchat.server.common.exception.KuchatException;
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.enums.Status;
 import kuchat.server.domain.message.Message;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-@Entity
+@Entity @ToString
 @Table(name = "chatroom")
 @Getter
 @NoArgsConstructor
@@ -60,5 +57,9 @@ public class Chatroom extends BaseTime {
         } else {
             throw new KuchatException(BaseResponse.EXIT_CHATROOM_FAIL);
         }
+    }
+
+    public void addChatroomMember(ChatroomMember chatroomMember) {
+        chatroomMembers.add(chatroomMember);
     }
 }

--- a/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
+++ b/src/main/java/kuchat/server/domain/chatroom/service/ChatroomService.java
@@ -79,6 +79,7 @@ public class ChatroomService {
         if (memberIds.size() != joinMembers.size()) {
             throw new KuchatException(NOT_FOUND_MEMBER);
         }
+        messageService.sendJoinMessage(joinMembers, chatroom);
 
         ArrayList<ChatroomMember> chatroomMembers = new ArrayList<>();
         log.info("[join] 지금 추가한 멤버 목록 = [{}]", chatroomMembers.stream()
@@ -90,6 +91,7 @@ public class ChatroomService {
             ChatroomMember chatroomMember = new ChatroomMember(member, chatroom);
             chatroomMembers.add(chatroomMember);
             member.addChatroomMember(chatroomMember);
+            chatroom.addChatroomMember(chatroomMember);
         }
 
         try {
@@ -98,12 +100,10 @@ public class ChatroomService {
             throw new KuchatException(DB_SAVE_FAIL);
         }
 
-        log.info("[join] 멤버 추가 후 채팅방 멤버 목록 = [{}}]", chatroom.getChatroomMembers().stream()
+        log.info("[join] 멤버 추가 후 채팅방 멤버 목록 = [{}]", chatroom.getChatroomMembers().stream()
                 .map(chatroomMember -> chatroomMember.getMember().getId().toString())
                 .collect(Collectors.joining(", "))
         );
-
-        messageService.sendEnterMessage(joinMembers, chatroom);
     }
 
     @Transactional

--- a/src/main/java/kuchat/server/domain/enums/MessageType.java
+++ b/src/main/java/kuchat/server/domain/enums/MessageType.java
@@ -1,5 +1,6 @@
 package kuchat.server.domain.enums;
 
+
 public enum MessageType {
     JOIN, TALK, REPLY, TRANSLATE, LEAVE;
 }

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -5,8 +5,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
-import kuchat.server.common.exception.BaseResponse;
-import kuchat.server.common.exception.KuchatException;
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.blockMember.BlockMember;
 import kuchat.server.domain.chatroom.ChatroomMember;
@@ -105,10 +103,11 @@ public class Member extends BaseTime {
     private String refreshToken;
 
     @Builder
-    public Member(String email, Platform platform, String attributeName) {
+    public Member(String email, Platform platform, String attributeName, String profileImage) {
         this.email = email;
         this.platform = platform;
         this.attributeName = attributeName;
+        this.profileImage = profileImage;
         role = Role.GUEST;
     }
 
@@ -122,26 +121,27 @@ public class Member extends BaseTime {
         this.secondLanguage = LearnLanguage.of(request.getSecondLanguage());
         this.hometown = request.getHometown();
         this.name = request.getName();
+        this.birthday = request.getBirthday();
         this.department = request.getDepartment();
         this.studentId = request.getStudentId();
         this.gender = Gender.of(request.getGender());
-        this.birthday = request.getBirthday();
-        this.email = request.getEmail();
 
+        this.role = Role.STUDENT;           // 추가정보 받은 후
+
+//        this.email = request.getEmail();
 //        if (validateEmail(email)) {
 //            this.email = request.getEmail();
 //        }
-        this.role = Role.STUDENT;           // 추가정보 받은 후
     }
 
-    private boolean validateEmail(String email) {
-        if (!email.contains("@konkuk.ac.kr")) {
-            log.info("[validateEmail] email = {}", email);
-            throw new KuchatException(BaseResponse.EMAIL_BAD_REQUEST);
-        } else {
-            return true;
-        }
-    }
+//    private boolean validateEmail(String email) {
+//        if (!email.contains("@konkuk.ac.kr")) {
+//            log.info("[validateEmail] email = {}", email);
+//            throw new KuchatException(BaseResponse.EMAIL_BAD_REQUEST);
+//        } else {
+//            return true;
+//        }
+//    }
 
     public void addChatroomMember(ChatroomMember chatroomMember) {
         chatroomMembers.add(chatroomMember);

--- a/src/main/java/kuchat/server/domain/message/ChatMessageEvent.java
+++ b/src/main/java/kuchat/server/domain/message/ChatMessageEvent.java
@@ -10,7 +10,7 @@ public class ChatMessageEvent extends ApplicationEvent {
     private WebSocketSession session;
     private ChatMessage chatMessage;
 
-    public ChatMessageEvent(Object source,ChatMessage chatMessage) {
+    public ChatMessageEvent(Object source, ChatMessage chatMessage) {
         super(source);
         this.chatMessage = chatMessage;
     }

--- a/src/main/java/kuchat/server/domain/message/Message.java
+++ b/src/main/java/kuchat/server/domain/message/Message.java
@@ -22,11 +22,6 @@ public class Message extends BaseTime {
     })
     private MessageId messageId;
 
-    @Column(name = "generated_message_id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "message_id_seq")
-    @SequenceGenerator(name = "message_id_seq", sequenceName = "message_id_seq", allocationSize = 1)
-    private Long generatedMessageId;
-
     // 메시지는 하나의 채팅방 안에서만 고유하도록 id 생성
     @MapsId("chatroomId")       // MessageId 클래스에 있는 chatroomId 변수와 매핑
     @ManyToOne
@@ -49,16 +44,8 @@ public class Message extends BaseTime {
 
     private String text;
 
-    @Builder
-    public Message(Chatroom chatroom, Long senderId, MessageType messageType, String text) {
-        this.chatroom = chatroom;
-        this.senderId = senderId;
-        this.messageType = messageType;
-        this.text = text;
-    }
 
     public Message(ChatMessage chatMessage, Chatroom chatroom) {
-        this.messageId = new MessageId(generatedMessageId, chatMessage.getChatroomId());
         this.chatroom = chatroom;
         this.messageType = chatMessage.getMessageType();
         this.senderId = chatMessage.getSenderId();

--- a/src/main/java/kuchat/server/domain/message/Message.java
+++ b/src/main/java/kuchat/server/domain/message/Message.java
@@ -5,10 +5,7 @@ import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.chatroom.Chatroom;
 import kuchat.server.domain.enums.MessageType;
 import kuchat.server.domain.message.dto.ChatMessage;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 @Entity
 @Table(name = "message")
@@ -17,12 +14,18 @@ import lombok.ToString;
 @ToString
 public class Message extends BaseTime {
 
+    @Setter
     @EmbeddedId
     @AttributeOverrides({
             @AttributeOverride(name = "messageId", column = @Column(name = "message_id")),
             @AttributeOverride(name = "chatroomId", column = @Column(name = "chatroom_id", insertable = false, updatable = false))
     })
     private MessageId messageId;
+
+    @Column(name = "generated_message_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "message_id_seq")
+    @SequenceGenerator(name = "message_id_seq", sequenceName = "message_id_seq", allocationSize = 1)
+    private Long generatedMessageId;
 
     // 메시지는 하나의 채팅방 안에서만 고유하도록 id 생성
     @MapsId("chatroomId")       // MessageId 클래스에 있는 chatroomId 변수와 매핑
@@ -55,20 +58,21 @@ public class Message extends BaseTime {
     }
 
     public Message(ChatMessage chatMessage, Chatroom chatroom) {
-        this.messageId = new MessageId(chatMessage.getMessageId(), chatMessage.getChatroomId());
+        this.messageId = new MessageId(generatedMessageId, chatMessage.getChatroomId());
         this.chatroom = chatroom;
         this.messageType = chatMessage.getMessageType();
         this.senderId = chatMessage.getSenderId();
         this.text = chatMessage.getText();
     }
 
+
     // 답장, 번역 메세지처럼 부모가 있는 메세지에 대한 생성자
     public Message(ChatMessage chatMessage, Chatroom chatroom, Message parent) {
-        this.messageId = new MessageId(chatMessage.getMessageId(), chatMessage.getChatroomId());
         this.chatroom = chatroom;
         this.messageType = chatMessage.getMessageType();
         this.senderId = chatMessage.getSenderId();
         this.parent = parent;
         this.text = chatMessage.getText();
     }
+
 }

--- a/src/main/java/kuchat/server/domain/message/Message.java
+++ b/src/main/java/kuchat/server/domain/message/Message.java
@@ -7,32 +7,23 @@ import kuchat.server.domain.enums.MessageType;
 import kuchat.server.domain.message.dto.ChatMessage;
 import lombok.*;
 
-@Entity
+@Entity @ToString
 @Table(name = "message")
 @Getter
 @NoArgsConstructor
-@ToString
 public class Message extends BaseTime {
 
-    @Setter
-    @EmbeddedId
-    @AttributeOverrides({
-            @AttributeOverride(name = "messageId", column = @Column(name = "message_id")),
-            @AttributeOverride(name = "chatroomId", column = @Column(name = "chatroom_id", insertable = false, updatable = false))
-    })
-    private MessageId messageId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long messageId;
 
-    // 메시지는 하나의 채팅방 안에서만 고유하도록 id 생성
-    @MapsId("chatroomId")       // MessageId 클래스에 있는 chatroomId 변수와 매핑
     @ManyToOne
     @JoinColumn(name = "chatroom_id")
     private Chatroom chatroom;
 
     @ManyToOne
-    @JoinColumns({
-            @JoinColumn(name = "parent_message_id", referencedColumnName = "message_id"),
-            @JoinColumn(name = "parent_chatroom_id", referencedColumnName = "chatroom_id"/*, insertable=false, updatable=false*/)
-    })
+    @JoinColumn(name = "parent_message_id", referencedColumnName = "message_id")
     private Message parent = null;       // chatroomId 없이 messageId만 가지면 된다.
 
     @Column(name = "sender_id")
@@ -43,7 +34,6 @@ public class Message extends BaseTime {
     private MessageType messageType;
 
     private String text;
-
 
     public Message(ChatMessage chatMessage, Chatroom chatroom) {
         this.chatroom = chatroom;

--- a/src/main/java/kuchat/server/domain/message/MessageId.java
+++ b/src/main/java/kuchat/server/domain/message/MessageId.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.Objects;
 
 @Getter
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Embeddable

--- a/src/main/java/kuchat/server/domain/message/MessageId.java
+++ b/src/main/java/kuchat/server/domain/message/MessageId.java
@@ -14,7 +14,7 @@ import java.util.Objects;
 @Embeddable
 public class MessageId implements Serializable {
 
-    private Long messageId;
+    private Long messageId;         // SQL 문으로 AUTO_INCREMENT 설정 해줌
     private Long chatroomId;        // @MapsId("chatroomId") 로 매핑
 
     @Override

--- a/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
@@ -18,8 +18,7 @@ public class ChatMessage {
     private Long parentId;
 
     @Builder
-    public ChatMessage(Long messageId, Long chatroomId, MessageType messageType, Long senderId, String text) {
-//        this.messageId = messageId;
+    public ChatMessage(Long chatroomId, MessageType messageType, Long senderId, String text) {
         this.chatroomId = chatroomId;
         this.messageType = messageType;
         this.senderId = senderId;
@@ -28,7 +27,6 @@ public class ChatMessage {
     }
 
     public ChatMessage(Message message) {
-//        this.messageId = message.getMessageId().getMessageId();
         this.chatroomId = message.getMessageId().getChatroomId();
         this.messageType = message.getMessageType();
         this.senderId = message.getSenderId();

--- a/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
@@ -7,9 +7,10 @@ import lombok.*;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @ToString
 public class ChatMessage {
-    private Long messageId;
+//    private Long messageId;
     private Long chatroomId;
     private MessageType messageType;
     private Long senderId;
@@ -17,8 +18,8 @@ public class ChatMessage {
     private Long parentId;
 
     @Builder
-    public ChatMessage(Long messageId, Long chatroomId, MessageType messageType, Long senderId, String text){
-        this.messageId = messageId;
+    public ChatMessage(Long messageId, Long chatroomId, MessageType messageType, Long senderId, String text) {
+//        this.messageId = messageId;
         this.chatroomId = chatroomId;
         this.messageType = messageType;
         this.senderId = senderId;
@@ -26,13 +27,13 @@ public class ChatMessage {
         this.parentId = null;
     }
 
-    public ChatMessage(Message message){
-        this.messageId = message.getMessageId().getMessageId();
+    public ChatMessage(Message message) {
+//        this.messageId = message.getMessageId().getMessageId();
         this.chatroomId = message.getMessageId().getChatroomId();
         this.messageType = message.getMessageType();
         this.senderId = message.getSenderId();
         this.text = message.getText();
         this.parentId = message.getParent().getMessageId().getMessageId();
     }
-    
+
 }

--- a/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatMessage.java
@@ -17,7 +17,6 @@ public class ChatMessage {
     private String text;
     private Long parentId;
 
-    @Builder
     public ChatMessage(Long chatroomId, MessageType messageType, Long senderId, String text) {
         this.chatroomId = chatroomId;
         this.messageType = messageType;
@@ -27,11 +26,11 @@ public class ChatMessage {
     }
 
     public ChatMessage(Message message) {
-        this.chatroomId = message.getMessageId().getChatroomId();
+        this.chatroomId = message.getMessageId();
         this.messageType = message.getMessageType();
         this.senderId = message.getSenderId();
         this.text = message.getText();
-        this.parentId = message.getParent().getMessageId().getMessageId();
+        this.parentId = message.getParent().getMessageId();
     }
 
 }

--- a/src/main/java/kuchat/server/domain/message/dto/ChatroomJoinRequest.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatroomJoinRequest.java
@@ -1,0 +1,23 @@
+package kuchat.server.domain.message.dto;
+
+import kuchat.server.domain.enums.MessageType;
+import lombok.*;
+
+import static kuchat.server.domain.message.service.MessageService.SERVER_ID;
+
+@Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatroomJoinRequest extends ChatMessage{
+    private Long memberId;
+    private Long chatroomId;
+    private Long senderId = SERVER_ID;
+    private MessageType messageType = MessageType.JOIN;
+    private String text = null;
+
+    @Builder
+    public ChatroomJoinRequest(Long chatroomId, Long memberId) {
+        this.chatroomId = chatroomId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/kuchat/server/domain/message/dto/ChatroomLeaveRequest.java
+++ b/src/main/java/kuchat/server/domain/message/dto/ChatroomLeaveRequest.java
@@ -1,0 +1,24 @@
+package kuchat.server.domain.message.dto;
+
+import kuchat.server.domain.enums.MessageType;
+import lombok.*;
+
+import static kuchat.server.domain.message.service.MessageService.SERVER_ID;
+
+@Getter @ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChatroomLeaveRequest extends ChatMessage{
+    private Long memberId;
+    private Long chatroomId;
+    private Long senderId = SERVER_ID;
+    private MessageType messageType = MessageType.LEAVE;
+    private String text;
+
+    @Builder
+    public ChatroomLeaveRequest(Long chatroomId, Long memberId, String text) {
+        this.chatroomId = chatroomId;
+        this.memberId = memberId;
+        this.text = text;
+    }
+}

--- a/src/main/java/kuchat/server/domain/message/dto/RecentMessagesResponse.java
+++ b/src/main/java/kuchat/server/domain/message/dto/RecentMessagesResponse.java
@@ -1,12 +1,10 @@
 package kuchat.server.domain.message.dto;
 
 import kuchat.server.domain.message.Message;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/kuchat/server/domain/message/service/MessageService.java
+++ b/src/main/java/kuchat/server/domain/message/service/MessageService.java
@@ -8,11 +8,11 @@ import kuchat.server.domain.enums.MessageType;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.message.ChatMessageEvent;
 import kuchat.server.domain.message.Message;
-import kuchat.server.domain.message.MessageId;
 import kuchat.server.domain.message.dto.ChatMessage;
+import kuchat.server.domain.message.dto.ChatroomJoinRequest;
+import kuchat.server.domain.message.dto.ChatroomLeaveRequest;
 import kuchat.server.domain.message.dto.RecentMessagesResponse;
 import kuchat.server.domain.message.repository.MessageRepository;
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -35,7 +35,7 @@ import static kuchat.server.common.exception.BaseResponse.NOT_FOUND_MESSAGE;
 @Service
 public class MessageService {
 
-    private static final Long SERVER_ID = (long) -1;
+    public static final Long SERVER_ID = (long) -1;
     private final MessageRepository messageRepository;
     private final ChatroomRepository chatroomRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -51,20 +51,27 @@ public class MessageService {
 
     // 멤버 1명 이상이 들어올 때, 서버가 채팅방 속 모든 클라이언트들에게 환영 메시지를 톡방에 보내는 메서드
     @Transactional
-    public void sendEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
-        ChatMessage enterMessage = createEnterMessage(joinMembers, chatroom);
-        saveMessage(new Message(enterMessage, chatroom));
-        ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, enterMessage);
-        eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
+    public void sendJoinMessage(List<Member> joinMembers, Chatroom chatroom) {
 
+        // 1. 해당 채팅방에 web socket session 을 추가하기 위한 join request를 전송 (JOIN)
         joinMembers.stream()
-                .map(member -> new ChatMessageEvent(this, ChatMessage.builder()
+                .map(member -> new ChatMessageEvent(this, ChatroomJoinRequest.builder()
+                        .memberId(member.getId())
                         .chatroomId(chatroom.getId())
-                        .messageType(MessageType.JOIN)
-                        .senderId(SERVER_ID)
-                        .text(null)
                         .build()))
                 .forEach(eventPublisher::publishEvent);
+
+        // 2. 다른 클라이언트에게도 입장을 알리기 위해 환영 문자를 전송 (TALK)
+        log.info("[sendEnterMessage] join members = {}, chatroom = {}", joinMembers.toString(), chatroom.toString());
+        ChatMessage enterMessage = createEnterMessage(joinMembers, chatroom);
+        log.info("[sendEnterMessage] 생성된 enterMessage = {}", enterMessage.toString());
+        messageRepository.save(new Message(enterMessage, chatroom));
+        log.info("[sendEnterMessage] 11111");
+        ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, enterMessage);
+        log.info("[sendEnterMessage] 22222");
+        eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
+        log.info("[sendEnterMessage] 끝!!!");
+
     }
 
     private ChatMessage createEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
@@ -72,31 +79,25 @@ public class MessageService {
                 .map(member -> member.getName())
                 .collect(Collectors.joining(", ")) + " 님이 입장했습니다.";
 
-        return ChatMessage.builder()
-                .chatroomId(chatroom.getId())
-                .messageType(MessageType.TALK)
-                .senderId(SERVER_ID)
-                .text(text)
-                .build();
+        return new ChatMessage(chatroom.getId(), MessageType.TALK, SERVER_ID, text);
     }
 
     // 멤버 1명이 나갈 때, 나갔음을 알리는 메시지를 보내는 메서드
     @Transactional
     public void sendLeaveMessage(Member member, Chatroom chatroom) {
-        ChatMessage leaveMessage = createLeaveMessage(member, chatroom);
-        saveMessage(new Message(leaveMessage, chatroom));
+        ChatroomLeaveRequest leaveMessage = createLeaveMessage(member, chatroom);
+        messageRepository.save(new Message(leaveMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, leaveMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
 
     }
 
-    private ChatMessage createLeaveMessage(Member member, Chatroom chatroom) {
+    private ChatroomLeaveRequest createLeaveMessage(Member member, Chatroom chatroom) {
         String text = "👋🏻" + member.getName() + " 님이 채팅방을 나갔습니다.";
 
-        return ChatMessage.builder()
+        return ChatroomLeaveRequest.builder()
                 .chatroomId(chatroom.getId())
-                .messageType(MessageType.LEAVE)
-                .senderId(SERVER_ID)
+                .memberId(member.getId())
                 .text(text)
                 .build();
     }
@@ -118,19 +119,11 @@ public class MessageService {
         try {
             // 이렇게 하면 generatedMessageId 는 모든 채팅방에 있는 메세지들에 대해서 1씩 증가하도록 설정된다.
             // 한 채팅방에 대해서만 generatedMessageId 가 1씩 증가하도록 만들고 싶은데, 이걸 어떻게 구현해야할까..
-            saveMessage(message);
-
+            messageRepository.save(message);
         } catch (DataAccessException e) {
             throw new KuchatException(DB_SAVE_FAIL);
         }
         return true;
-    }
-
-    private void saveMessage(Message message) {
-        Message savedMessage = messageRepository.save(message);
-        MessageId messageId = new MessageId(savedMessage.getMessageId().getMessageId(), savedMessage.getChatroom().getId());
-        log.info("[saveMessage] 저장된 메세지의 message id = {}, text = {}", savedMessage.getMessageId().getMessageId(), savedMessage.getText());
-        savedMessage.setMessageId(messageId);
     }
 
 }

--- a/src/main/java/kuchat/server/domain/message/service/MessageService.java
+++ b/src/main/java/kuchat/server/domain/message/service/MessageService.java
@@ -51,7 +51,7 @@ public class MessageService {
     @Transactional
     public void sendEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
         ChatMessage enterMessage = createEnterMessage(joinMembers, chatroom);
-        messageRepository.save(new Message(enterMessage, chatroom));
+        saveMessage(new Message(enterMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, enterMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
     }
@@ -74,7 +74,7 @@ public class MessageService {
     @Transactional
     public void sendLeaveMessage(Member member, Chatroom chatroom) {
         ChatMessage leaveMessage = createLeaveMessage(member, chatroom);
-        messageRepository.save(new Message(leaveMessage, chatroom));
+        saveMessage(new Message(leaveMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, leaveMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
     }
@@ -108,15 +108,19 @@ public class MessageService {
         try {
             // 이렇게 하면 generatedMessageId 는 모든 채팅방에 있는 메세지들에 대해서 1씩 증가하도록 설정된다.
             // 한 채팅방에 대해서만 generatedMessageId 가 1씩 증가하도록 만들고 싶은데, 이걸 어떻게 구현해야할까..
-            Message savedMessage = messageRepository.save(message);
-            MessageId messageId = new MessageId(savedMessage.getGeneratedMessageId(), savedMessage.getChatroom().getId());
-            log.info("저장된 메세지의 id = {}, text = {}", savedMessage.getGeneratedMessageId(), savedMessage.getText());
-            savedMessage.setMessageId(messageId);
+            saveMessage(message);
 
         } catch (DataAccessException e) {
             throw new KuchatException(DB_SAVE_FAIL);
         }
         return true;
+    }
+
+    private void saveMessage(Message message) {
+        Message savedMessage = messageRepository.save(message);
+        MessageId messageId = new MessageId(savedMessage.getMessageId().getMessageId(), savedMessage.getChatroom().getId());
+        log.info("[saveMessage] 저장된 메세지의 message id = {}, text = {}", savedMessage.getMessageId().getMessageId(), savedMessage.getText());
+        savedMessage.setMessageId(messageId);
     }
 
 }

--- a/src/main/java/kuchat/server/domain/message/service/MessageService.java
+++ b/src/main/java/kuchat/server/domain/message/service/MessageService.java
@@ -6,15 +6,16 @@ import kuchat.server.domain.chatroom.Chatroom;
 import kuchat.server.domain.chatroom.repository.ChatroomRepository;
 import kuchat.server.domain.enums.MessageType;
 import kuchat.server.domain.member.Member;
-import kuchat.server.domain.member.repository.MemberRepository;
 import kuchat.server.domain.message.ChatMessageEvent;
 import kuchat.server.domain.message.Message;
+import kuchat.server.domain.message.MessageId;
 import kuchat.server.domain.message.dto.ChatMessage;
 import kuchat.server.domain.message.dto.RecentMessagesResponse;
 import kuchat.server.domain.message.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static kuchat.server.common.exception.BaseResponse.DB_SAVE_FAIL;
 import static kuchat.server.common.exception.BaseResponse.NOT_FOUND_MESSAGE;
 
 
@@ -34,31 +36,28 @@ public class MessageService {
 
     private final MessageRepository messageRepository;
     private final ChatroomRepository chatroomRepository;
-    private final MemberRepository memberRepository;
     private final ApplicationEventPublisher eventPublisher;
 
 
     public RecentMessagesResponse findRecentMessages(Chatroom chatroom) {
+        log.info("[findRecentMessages] 클라이언트가 접속한 채팅방 id = {}", chatroom.getId());
         Pageable pageable = PageRequest.of(0, 20);
         List<Message> messages = messageRepository.findRecent20MessagesByChatroomId(chatroom, pageable);
+        log.info("[findRecentMessages] 조회한 20개 이하 메세지 = {}", messages.toString());
         return new RecentMessagesResponse(messages);
     }
 
-    // Message 객체 생성 후 DB에 저장
-    @Transactional
-    public Message createMessage() {
-        return null;
-    }
-
     // 멤버 1명 이상이 들어올 때, 서버가 채팅방 속 모든 클라이언트들에게 환영 메시지를 톡방에 보내는 메서드
+    @Transactional
     public void sendEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
         ChatMessage enterMessage = createEnterMessage(joinMembers, chatroom);
+        messageRepository.save(new Message(enterMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, enterMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
     }
 
     private ChatMessage createEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
-        String text = "👋🏻 " + joinMembers.stream()
+        String text = "👋🏻" + joinMembers.stream()
                 .map(member -> member.getName())
                 .collect(Collectors.joining(", ")) + " 님이 입장했습니다.";
 
@@ -72,15 +71,16 @@ public class MessageService {
     }
 
     // 멤버 1명이 나갈 때, 나갔음을 알리는 메시지를 보내는 메서드
+    @Transactional
     public void sendLeaveMessage(Member member, Chatroom chatroom) {
         ChatMessage leaveMessage = createLeaveMessage(member, chatroom);
+        messageRepository.save(new Message(leaveMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, leaveMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
-
     }
 
     private ChatMessage createLeaveMessage(Member member, Chatroom chatroom) {
-        String text = "👋🏻 " + member.getName() + " 님이 채팅방을 나갔습니다.";
+        String text = "👋🏻" + member.getName() + " 님이 채팅방을 나갔습니다.";
 
         return ChatMessage.builder()
                 .messageId(null)
@@ -93,7 +93,7 @@ public class MessageService {
 
     // 서버가 클라이언트로부터 받은 메세지를 처리하는 부분 (DB에 저장 및 전달)
     @Transactional
-    public void handleReceivedMessage(ChatMessage chatMessage) {
+    public boolean handleReceivedMessage(ChatMessage chatMessage) {
         Chatroom chatroom = chatroomRepository.findById(chatMessage.getChatroomId())
                 .orElseThrow(() -> new KuchatException(BaseResponse.NOT_FOUND_CHATROOM));
 
@@ -105,9 +105,18 @@ public class MessageService {
         }
         message = new Message(chatMessage, chatroom);
 
-        messageRepository.save(message);
-        ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, chatMessage);
-        eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
+        try {
+            // 이렇게 하면 generatedMessageId 는 모든 채팅방에 있는 메세지들에 대해서 1씩 증가하도록 설정된다.
+            // 한 채팅방에 대해서만 generatedMessageId 가 1씩 증가하도록 만들고 싶은데, 이걸 어떻게 구현해야할까..
+            Message savedMessage = messageRepository.save(message);
+            MessageId messageId = new MessageId(savedMessage.getGeneratedMessageId(), savedMessage.getChatroom().getId());
+            log.info("저장된 메세지의 id = {}, text = {}", savedMessage.getGeneratedMessageId(), savedMessage.getText());
+            savedMessage.setMessageId(messageId);
+
+        } catch (DataAccessException e) {
+            throw new KuchatException(DB_SAVE_FAIL);
+        }
+        return true;
     }
 
 }

--- a/src/main/java/kuchat/server/domain/message/service/MessageService.java
+++ b/src/main/java/kuchat/server/domain/message/service/MessageService.java
@@ -12,6 +12,7 @@ import kuchat.server.domain.message.MessageId;
 import kuchat.server.domain.message.dto.ChatMessage;
 import kuchat.server.domain.message.dto.RecentMessagesResponse;
 import kuchat.server.domain.message.repository.MessageRepository;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -34,6 +35,7 @@ import static kuchat.server.common.exception.BaseResponse.NOT_FOUND_MESSAGE;
 @Service
 public class MessageService {
 
+    private static final Long SERVER_ID = (long) -1;
     private final MessageRepository messageRepository;
     private final ChatroomRepository chatroomRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -54,6 +56,15 @@ public class MessageService {
         saveMessage(new Message(enterMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, enterMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
+
+        joinMembers.stream()
+                .map(member -> new ChatMessageEvent(this, ChatMessage.builder()
+                        .chatroomId(chatroom.getId())
+                        .messageType(MessageType.JOIN)
+                        .senderId(SERVER_ID)
+                        .text(null)
+                        .build()))
+                .forEach(eventPublisher::publishEvent);
     }
 
     private ChatMessage createEnterMessage(List<Member> joinMembers, Chatroom chatroom) {
@@ -62,10 +73,9 @@ public class MessageService {
                 .collect(Collectors.joining(", ")) + " 님이 입장했습니다.";
 
         return ChatMessage.builder()
-                .messageId(null)
                 .chatroomId(chatroom.getId())
-                .messageType(MessageType.JOIN)
-                .senderId(null)
+                .messageType(MessageType.TALK)
+                .senderId(SERVER_ID)
                 .text(text)
                 .build();
     }
@@ -77,16 +87,16 @@ public class MessageService {
         saveMessage(new Message(leaveMessage, chatroom));
         ChatMessageEvent chatMessageEvent = new ChatMessageEvent(this, leaveMessage);
         eventPublisher.publishEvent(chatMessageEvent);      // WebSocketHandler 의 onChatMessageEvent 메서드가 실행됨
+
     }
 
     private ChatMessage createLeaveMessage(Member member, Chatroom chatroom) {
         String text = "👋🏻" + member.getName() + " 님이 채팅방을 나갔습니다.";
 
         return ChatMessage.builder()
-                .messageId(null)
                 .chatroomId(chatroom.getId())
                 .messageType(MessageType.LEAVE)
-                .senderId(null)
+                .senderId(SERVER_ID)
                 .text(text)
                 .build();
     }

--- a/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
+++ b/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
@@ -1,13 +1,12 @@
-package kuchat.server.common.socket;
+package kuchat.server.domain.message.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kuchat.server.common.exception.BaseResponse;
 import kuchat.server.common.exception.KuchatException;
-import kuchat.server.domain.chatroom.service.ChatroomService;
+import kuchat.server.domain.enums.MessageType;
 import kuchat.server.domain.message.ChatMessageEvent;
 import kuchat.server.domain.message.dto.ChatMessage;
-import kuchat.server.domain.message.service.MessageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -18,7 +17,6 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -30,19 +28,15 @@ import static kuchat.server.common.exception.BaseResponse.*;
 public class WebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
-
-    private final Set<WebSocketSession> sessions = new HashSet<>();         // 현재 연결된 세션들
     private final ConcurrentHashMap<Long, Set<WebSocketSession>> chatroomSessions = new ConcurrentHashMap<>();          // chatroom id - session 매핑
     private final MessageService messageService;
-    private final ChatroomService chatroomService;
 
-    // 사용자가 웹소켓 서버에 접속할 때 동작을 구현 (join하는 chatroom에 클라이언트의 세션 추가하기)
+    // 클라이언트가 WebSocket 서버에 접속/연결할 때 호출되는 메서드 (join하는 chatroom에 클라이언트의 세션 추가하기)
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
-        String path = session.getUri().toString();
-        String tmpPath = path.replace("/join", "");     // path 형태 : {도메인}/chatroom/{chatroomId}
-        Long chatroomId = extractChatroomId(tmpPath);
-        findSessionsByChatroomId(chatroomId).add(session);
+        log.info("[afterConnectionEstablished] websocket 서버에 접속을 시도한 클라이언트의 세션 id = {}", session.getId());
+        TextMessage welcomeMessage = new TextMessage("web socket 서버 접속에 성공했습니다.");
+        sendMessage(session, welcomeMessage, WEBSOCKET_CONNECTION_FAIL);
     }
 
     // /chatroom/{chatroomId}로 끝나는 uri에서 chatroomId 추출하는 메서드
@@ -57,50 +51,57 @@ public class WebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-    // 사용자의 웹소켓 서버 접속이 끝났을 때 동작을 구현 (leave 하는 chatroom에 클라이언트의 세션 제거하기)
+    // 클라이언트가 WebSocket 서버와의 연결을 종료할 때 호출되는 메서드 (leave 하는 chatroom에 클라이언트의 세션 제거하기)
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        String path = session.getUri().toString();          // 멤버 나가기 uri : /chatroom/{chatroomId}/memberId/{memberId}/leave
-        String tmpPath = path.split("/memberId")[0];        // tmpPath 형태 : /chatroom/{chatroomId}
-        Long chatroomId = extractChatroomId(tmpPath);
-        findSessionsByChatroomId(chatroomId).remove(session);
+        log.info("[afterConnectionClosed] websocket 서버와의 연결을 종료한 클라이언트의 세션 id = {}", session.getId());
+        TextMessage farewellMessage = new TextMessage("web socket 서버와의 연결을 종료합니다.");
+        sendMessage(session, farewellMessage, WEBSOCKET_CLOSE_FAIL);
+
     }
 
-    // 클라이언트 -> (웹소켓)서버 로 온 메세지를 처리
+    // 클라이언트가 WebSocket 서버로 메시지를 전송할 때 호출되는 메서드
     @Override
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
-        String sessionId = session.getId();        // 메세지를 보낸 사람의 세션 아이디
-        String text = message.getPayload();
+        log.info("[handleTextMessage] 메세지를 전송한 클라이언트의 세션 id = {}, 메세지의 payload = {}", session.getId(), message.getPayload());
         ChatMessage chatMessage = toChatMessage(message);
-        log.info("[handleTextMessage] 받은 메시지의 세션 id = {}, 메시지의 payload = {}", sessionId, text);
-        messageService.handleReceivedMessage(chatMessage);
+        if (messageService.handleReceivedMessage(chatMessage)) {
+            sendMessageToClients(chatMessage.getChatroomId(), message);
+        }
     }
 
-    // 서버 -> 클라이언트 로 전송할 메시지를 처리  (MessageService에서 생성한 ChatMessage를 전송)
+    // 서버 -> 클라이언트 로 전송할 메시지를 처리  (MessageService 에서 생성한 ChatMessage 를 전송)
+    // 클라언트가 특정 채팅방에 join 혹은 leave 할 때 event 가 발생됨
     @EventListener
     public void onChatMessageEvent(ChatMessageEvent event) {
         ChatMessage chatMessage = event.getChatMessage();
         TextMessage textMessage = toTextMessage(chatMessage);
-        log.info("[send] 메시지 : {}", chatMessage.toString());
-        Set<WebSocketSession> sessions = findSessionsByChatroomId(chatMessage.getChatroomId());
+        sendMessageToClients(chatMessage.getChatroomId(), textMessage);
+    }
+
+    private void sendMessageToClients(Long chatroomId, TextMessage textMessage) {
+        log.info("[send] 메시지 : {}", textMessage.getPayload());
+        Set<WebSocketSession> sessions = findSessionsByChatroomId(chatroomId);
 
         if (sessions != null) {
             sessions.stream()
                     .filter(WebSocketSession::isOpen)
                     .forEach(session -> {
-                        sendMessage(session, textMessage);
+                        sendMessage(session, textMessage, MESSAGE_SEND_FAIL);
                     });
         }
     }
 
-    private Set<WebSocketSession> findSessionsByChatroomId(Long chatroomId){
+    private Set<WebSocketSession> findSessionsByChatroomId(Long chatroomId) {
         return chatroomSessions.get(chatroomId);
     }
 
-    private ChatMessage toChatMessage(TextMessage message) {
+    private ChatMessage toChatMessage(TextMessage textMessage) {
+        log.info("[toChatMessage] textMessage를 ChatMessage로 바꿔주는 메서드, textMessage = {}", textMessage.getPayload());
         try {
-            return objectMapper.readValue(message.getPayload(), ChatMessage.class);
-        } catch (IOException e) {
+//            return new ChatMessage(textMessage);
+            return objectMapper.readValue(textMessage.getPayload(), ChatMessage.class);
+        } catch (Exception e) {
             throw new KuchatException(CONVERT_TO_OBJECT_FAIL);
         }
     }
@@ -113,11 +114,11 @@ public class WebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-    private static void sendMessage(WebSocketSession session, TextMessage message) {
+    private static void sendMessage(WebSocketSession session, TextMessage message, BaseResponse response) {
         try {
             session.sendMessage(message);
         } catch (IOException e) {
-            throw new KuchatException(MESSAGE_SEND_FAIL);
+            throw new KuchatException(response);
         }
     }
 

--- a/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
+++ b/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kuchat.server.common.exception.BaseResponse;
 import kuchat.server.common.exception.KuchatException;
-import kuchat.server.domain.enums.MessageType;
+import kuchat.server.common.redis.RedisController;
 import kuchat.server.domain.message.ChatMessageEvent;
 import kuchat.server.domain.message.dto.ChatMessage;
+import kuchat.server.domain.message.dto.ChatroomJoinRequest;
+import kuchat.server.domain.message.dto.ChatroomLeaveRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -35,6 +37,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
     private final MessageService messageService;
+    private final RedisController redisController;
 
     private ConcurrentHashMap<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();         // member id - webSocketSession
     private ConcurrentHashMap<Long, Set<WebSocketSession>> chatroomSessions = new ConcurrentHashMap<>();          // chatroom id - session 매핑
@@ -43,9 +46,10 @@ public class WebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
         String query = session.getUri().getQuery();     // ws://localhost:9000/ws/message?memberId={id}
-        Map<String, String> queryParams =  parseQueryParam(query);
+        Map<String, String> queryParams = parseQueryParam(query);
         Long memberId = Long.parseLong(queryParams.get("memberId"));
         sessions.put(memberId, session);
+        redisController.putMemberSession(memberId, session.getId());
         log.info("[afterConnectionEstablished] websocket 서버에 접속을 시도한 클라이언트의 세션 id = {}, member id = {}",
                 session.getId(), memberId);
         TextMessage welcomeMessage = new TextMessage("web socket 서버 접속에 성공했습니다.");
@@ -54,7 +58,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
 
     private Map<String, String> parseQueryParam(String query) {
         Map<String, String> queryParams = new HashMap<>();
-        if(query != null && !query.isEmpty()){
+        if (query != null && !query.isEmpty()) {
             String[] pairs = query.split("&");
             for (String pair : pairs) {
                 int idx = pair.indexOf("=");
@@ -74,7 +78,7 @@ public class WebSocketHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         String query = session.getUri().getQuery();     // ws://localhost:9000/ws/message?memberId={id}
-        Map<String, String> queryParams =  parseQueryParam(query);
+        Map<String, String> queryParams = parseQueryParam(query);
         Long memberId = Long.parseLong(queryParams.get("memberId"));
         log.info("[afterConnectionClosed] websocket 서버와의 연결을 종료한 클라이언트의 세션 id = {}, member id = {}",
                 session.getId(), memberId);
@@ -87,6 +91,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) {
         log.info("[handleTextMessage] 메세지를 전송한 클라이언트의 세션 id = {}, 메세지의 payload = {}", session.getId(), message.getPayload());
         ChatMessage chatMessage = toChatMessage(message);
+        log.info("[toChatMessage] textMessage 를 chatMessage 로 바꾸는데 성공. chatMessage = {}", chatMessage.toString());
+
         if (messageService.handleReceivedMessage(chatMessage)) {
             sendMessageToClients(chatMessage.getChatroomId(), message);
         }
@@ -97,21 +103,31 @@ public class WebSocketHandler extends TextWebSocketHandler {
     @EventListener
     public void onChatMessageEvent(ChatMessageEvent event) {
         ChatMessage chatMessage = event.getChatMessage();
-
-        if(chatMessage.getMessageType() == JOIN){
-            WebSocketSession webSocketSession = sessions.get(chatMessage.getSenderId());
-            Set<WebSocketSession> chatroomSessions = this.chatroomSessions.get(chatMessage.getChatroomId());
+        if (chatMessage.getMessageType() == JOIN) {
+            ChatroomJoinRequest joinRequest = (ChatroomJoinRequest) chatMessage;
+            WebSocketSession webSocketSession = getSession(joinRequest.getMemberId());
+            log.info("[onChatMessageEvent : JOIN] 세션을 추가할 멤버의 id = {}, session id = {}",
+                    joinRequest.getMemberId(), webSocketSession.getId());
+            Set<WebSocketSession> chatroomSessions = getSessionSet(joinRequest.getChatroomId());
+            log.info("[onChatMessageEvent : JOIN] 세션을 추가하기 전 set = {}", chatroomSessions.toString());
             chatroomSessions.add(webSocketSession);
+            log.info("[onChatMessageEvent : JOIN] 세션을 추가한 후 set = {}", chatroomSessions.toString());
+
+            redisController.putChatroomSession(chatMessage.getChatroomId(),
+                    chatMessage.getSenderId(), webSocketSession.getId());
             return;
         }
 
-        if(chatMessage.getMessageType() == LEAVE){
-            WebSocketSession webSocketSession = sessions.get(chatMessage.getSenderId());
-            Set<WebSocketSession> chatroomSessions = this.chatroomSessions.get(chatMessage.getChatroomId());
+        if (chatMessage.getMessageType() == LEAVE) {
+            ChatroomLeaveRequest joinRequest = (ChatroomLeaveRequest) chatMessage;
+            WebSocketSession webSocketSession = getSession(joinRequest.getMemberId());
+            Set<WebSocketSession> chatroomSessions = this.chatroomSessions.get(joinRequest.getChatroomId());
             chatroomSessions.remove(webSocketSession);
+            redisController.deleteChatroomSession(joinRequest.getChatroomId(), joinRequest.getSenderId());
         }
 
-        if(chatMessage.getText() == null){
+        if (chatMessage.getText() == null) {
+            log.info("[onChatMessageEvent] 메세지의 payload 가 비어있어 전송하지 않음. chatMessage = {}", chatMessage.toString());
             return;
         }
 
@@ -119,29 +135,38 @@ public class WebSocketHandler extends TextWebSocketHandler {
         sendMessageToClients(chatMessage.getChatroomId(), textMessage);
     }
 
-    private void sendMessageToClients(Long chatroomId, TextMessage textMessage) {
-        log.info("[send] 메시지 : {}", textMessage.getPayload());
-        Set<WebSocketSession> sessions = findSessionsByChatroomId(chatroomId);
-
-        if (sessions != null) {
-            sessions.stream()
-                    .filter(WebSocketSession::isOpen)
-                    .forEach(session -> {
-                        sendMessage(session, textMessage, MESSAGE_SEND_FAIL);
-                    });
+    private WebSocketSession getSession(Long memberId) {
+        log.info("[getSession] member id로 web socket session 찾기. member id  = {}", memberId);
+        WebSocketSession webSocketSession = sessions.get(memberId);
+        log.info("[getSession] member id로 web socket session 찾기. web socket session id = {}", webSocketSession.getId());
+        if (webSocketSession == null) {
+            throw new KuchatException(NOT_FOUND_SESSION);
         }
+        return webSocketSession;
     }
 
-    private Set<WebSocketSession> findSessionsByChatroomId(Long chatroomId) {
-        return chatroomSessions.get(chatroomId);
+    private void sendMessageToClients(Long chatroomId, TextMessage textMessage) {
+        log.info("[sendMessageToClients] 메시지 = {}", textMessage.getPayload());
+        Set<WebSocketSession> sessions = getSessionSet(chatroomId);
+
+        sessions.stream()
+                .filter(WebSocketSession::isOpen)
+                .forEach(session -> {
+                    sendMessage(session, textMessage, MESSAGE_SEND_FAIL);
+                });
+
+    }
+
+    private Set<WebSocketSession> getSessionSet(Long chatroomId) {
+        return chatroomSessions.computeIfAbsent(chatroomId, key -> ConcurrentHashMap.newKeySet());
     }
 
     private ChatMessage toChatMessage(TextMessage textMessage) {
         log.info("[toChatMessage] textMessage를 ChatMessage로 바꿔주는 메서드, textMessage = {}", textMessage.getPayload());
         try {
-//            return new ChatMessage(textMessage);
             return objectMapper.readValue(textMessage.getPayload(), ChatMessage.class);
         } catch (Exception e) {
+            log.info("[toChatMessage] textMessage 를 chatMessage 로 바꾸는데 실패함");
             throw new KuchatException(CONVERT_TO_OBJECT_FAIL);
         }
     }
@@ -159,6 +184,8 @@ public class WebSocketHandler extends TextWebSocketHandler {
             session.sendMessage(message);
         } catch (IOException e) {
             throw new KuchatException(response);
+        } catch (IllegalStateException e){
+            throw new KuchatException(WEBSOCKET_DISCONNECT);
         }
     }
 

--- a/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
+++ b/src/main/java/kuchat/server/domain/message/service/WebSocketHandler.java
@@ -17,10 +17,16 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static kuchat.server.common.exception.BaseResponse.*;
+import static kuchat.server.domain.enums.MessageType.JOIN;
+import static kuchat.server.domain.enums.MessageType.LEAVE;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,36 +34,52 @@ import static kuchat.server.common.exception.BaseResponse.*;
 public class WebSocketHandler extends TextWebSocketHandler {
 
     private final ObjectMapper objectMapper;
-    private final ConcurrentHashMap<Long, Set<WebSocketSession>> chatroomSessions = new ConcurrentHashMap<>();          // chatroom id - session 매핑
     private final MessageService messageService;
 
-    // 클라이언트가 WebSocket 서버에 접속/연결할 때 호출되는 메서드 (join하는 chatroom에 클라이언트의 세션 추가하기)
+    private ConcurrentHashMap<Long, WebSocketSession> sessions = new ConcurrentHashMap<>();         // member id - webSocketSession
+    private ConcurrentHashMap<Long, Set<WebSocketSession>> chatroomSessions = new ConcurrentHashMap<>();          // chatroom id - session 매핑
+
+    // 클라이언트가 WebSocket 서버에 접속/연결할 때 호출되는 메서드
     @Override
     public void afterConnectionEstablished(WebSocketSession session) {
-        log.info("[afterConnectionEstablished] websocket 서버에 접속을 시도한 클라이언트의 세션 id = {}", session.getId());
+        String query = session.getUri().getQuery();     // ws://localhost:9000/ws/message?memberId={id}
+        Map<String, String> queryParams =  parseQueryParam(query);
+        Long memberId = Long.parseLong(queryParams.get("memberId"));
+        sessions.put(memberId, session);
+        log.info("[afterConnectionEstablished] websocket 서버에 접속을 시도한 클라이언트의 세션 id = {}, member id = {}",
+                session.getId(), memberId);
         TextMessage welcomeMessage = new TextMessage("web socket 서버 접속에 성공했습니다.");
         sendMessage(session, welcomeMessage, WEBSOCKET_CONNECTION_FAIL);
     }
 
-    // /chatroom/{chatroomId}로 끝나는 uri에서 chatroomId 추출하는 메서드
-    private Long extractChatroomId(String path) {
-        try {
-            // path 형태 : {도메인}/chatroom/{chatroomId}/join
-            Long chatroomId = Long.parseLong(path.split("/chatroom")[1]);
-            return chatroomId;
-        } catch (NumberFormatException e) {
-            log.error("uri의 채팅방 id가 올바르지 않습니다. uri = {}", path);
-            throw new KuchatException(BaseResponse.MALFORMED_CHATROOM_ID);
+    private Map<String, String> parseQueryParam(String query) {
+        Map<String, String> queryParams = new HashMap<>();
+        if(query != null && !query.isEmpty()){
+            String[] pairs = query.split("&");
+            for (String pair : pairs) {
+                int idx = pair.indexOf("=");
+                if (idx != -1) {     // '='이 포함된 경우
+                    String key = URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8);
+                    String value = URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8);
+                    queryParams.put(key, value);
+                } else {            // '=' 없이 키만 있는 경우
+                    queryParams.put(URLDecoder.decode(pair, StandardCharsets.UTF_8), null);
+                }
+            }
         }
+        return queryParams;
     }
 
     // 클라이언트가 WebSocket 서버와의 연결을 종료할 때 호출되는 메서드 (leave 하는 chatroom에 클라이언트의 세션 제거하기)
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-        log.info("[afterConnectionClosed] websocket 서버와의 연결을 종료한 클라이언트의 세션 id = {}", session.getId());
+        String query = session.getUri().getQuery();     // ws://localhost:9000/ws/message?memberId={id}
+        Map<String, String> queryParams =  parseQueryParam(query);
+        Long memberId = Long.parseLong(queryParams.get("memberId"));
+        log.info("[afterConnectionClosed] websocket 서버와의 연결을 종료한 클라이언트의 세션 id = {}, member id = {}",
+                session.getId(), memberId);
         TextMessage farewellMessage = new TextMessage("web socket 서버와의 연결을 종료합니다.");
         sendMessage(session, farewellMessage, WEBSOCKET_CLOSE_FAIL);
-
     }
 
     // 클라이언트가 WebSocket 서버로 메시지를 전송할 때 호출되는 메서드
@@ -75,6 +97,24 @@ public class WebSocketHandler extends TextWebSocketHandler {
     @EventListener
     public void onChatMessageEvent(ChatMessageEvent event) {
         ChatMessage chatMessage = event.getChatMessage();
+
+        if(chatMessage.getMessageType() == JOIN){
+            WebSocketSession webSocketSession = sessions.get(chatMessage.getSenderId());
+            Set<WebSocketSession> chatroomSessions = this.chatroomSessions.get(chatMessage.getChatroomId());
+            chatroomSessions.add(webSocketSession);
+            return;
+        }
+
+        if(chatMessage.getMessageType() == LEAVE){
+            WebSocketSession webSocketSession = sessions.get(chatMessage.getSenderId());
+            Set<WebSocketSession> chatroomSessions = this.chatroomSessions.get(chatMessage.getChatroomId());
+            chatroomSessions.remove(webSocketSession);
+        }
+
+        if(chatMessage.getText() == null){
+            return;
+        }
+
         TextMessage textMessage = toTextMessage(chatMessage);
         sendMessageToClients(chatMessage.getChatroomId(), textMessage);
     }

--- a/src/main/resources/templates/signup.mustache
+++ b/src/main/resources/templates/signup.mustache
@@ -18,18 +18,34 @@
                 <!--                    <input type="text" class="form-control" id="setLanguage" placeholder="사이트 설정 언어를 입력하세요.">-->
                 <input type="text" class="form-control" id="setLanguage" placeholder="Please enter the site language.">
             </div>
+
+            <div class="form-group">
+                <!--                    <label for="firstLanguage">1지망 학습언어</label>-->
+                <label for="firstLanguage">1st learning language</label>
+                <!--                    <input class="form-control" id="firstLanguage" placeholder="첫번째로 학습하고 싶은 언어를 입력하세요.">-->
+                <input class="form-control" id="firstLanguage" placeholder="Enter the first language you want to learn.">
+            </div>
+            <div class="form-group">
+                <!--                    <label for="secondLanguage">2지망 학습언어</label>-->
+                <label for="secondLanguage">2nd earning language</label>
+                <!--                    <input class="form-control" id="secondLanguage" placeholder="두번째로 학습하고 싶은 언어를 입력하세요.">-->
+                <input class="form-control" id="secondLanguage" placeholder="Enter the second language you want to learn.">
+            </div>
+
+            <div class="form-group">
+                <!--                    <label for="hometown">출신 국가</label>-->
+                <label for="hometown">home town</label>
+                <!--                    <input class="form-control" id="hometown" placeholder="출신 국가를 입력하세요.">-->
+                <input class="form-control" id="hometown" placeholder="Enter your country of origin.">
+            </div>
+
             <div class="form-group">
                 <!--                    <label for="name">이름</label>-->
                 <label for="name">name</label>
                 <!--                    <input type="text" class="form-control" id="name" placeholder="이름을 입력하세요.">-->
                 <input type="text" class="form-control" id="name" placeholder="Please enter your name.">
             </div>
-            <div class="form-group">
-                <!--                    <label for="gender">성별</label>-->
-                <label for="gender">gender</label>
-                <!--                    <input type="text" class="form-control" id="gender" placeholder="성별을 입력하세요. (남/녀)">-->
-                <input type="text" class="form-control" id="gender" placeholder="Enter gender. (Male/Female)">
-            </div>
+
             <div class="form-group">
                 <!--                    <label for="birthday">생년월일</label>-->
                 <label for="birthday">birthday</label>
@@ -48,29 +64,14 @@
                 <!--                    <input type="text" class="form-control" id="studentId" placeholder="학번을 입력하세요. (ex. 202212368)">-->
                 <input type="text" class="form-control" id="studentId" placeholder="Enter your student ID. (ex. 202212368)">
             </div>
+
             <div class="form-group">
-                <!--                    <label for="hometown">출신 국가</label>-->
-                <label for="hometown">home town</label>
-                <!--                    <input class="form-control" id="hometown" placeholder="출신 국가를 입력하세요.">-->
-                <input class="form-control" id="hometown" placeholder="Enter your country of origin.">
+                <!--                    <label for="gender">성별</label>-->
+                <label for="gender">gender</label>
+                <!--                    <input type="text" class="form-control" id="gender" placeholder="성별을 입력하세요. (남/녀)">-->
+                <input type="text" class="form-control" id="gender" placeholder="Enter gender. (Male/Female)">
             </div>
-            <div class="form-group">
-                <!--                    <label for="firstLanguage">1지망 학습언어</label>-->
-                <label for="firstLanguage">1st learning language</label>
-                <!--                    <input class="form-control" id="firstLanguage" placeholder="첫번째로 학습하고 싶은 언어를 입력하세요.">-->
-                <input class="form-control" id="firstLanguage" placeholder="Enter the first language you want to learn.">
-            </div>
-            <div class="form-group">
-                <!--                    <label for="secondLanguage">2지망 학습언어</label>-->
-                <label for="secondLanguage">2nd earning language</label>
-                <!--                    <input class="form-control" id="secondLanguage" placeholder="두번째로 학습하고 싶은 언어를 입력하세요.">-->
-                <input class="form-control" id="secondLanguage" placeholder="Enter the second language you want to learn.">
-            </div>
-            <div class="form-group">
-                <label for="firstLanguage">email</label>
-                <!--                    <input class="form-control" id="firstLanguage" placeholder="첫번째로 학습하고 싶은 언어를 입력하세요.">-->
-                <input class="form-control" id="email" placeholder="Enter your email.">
-            </div>
+
 
             <button type="submit" class="btn btn-sm btn-success active">sign up</button>
             <a href="/" role="button" class="btn btn-secondary">cancel</a>
@@ -114,11 +115,10 @@
                 secondLanguage: $('#secondLanguage').val(),
                 hometown: $('#hometown').val(),
                 name: $('#name').val(),
+                birthday: $('#birthday').val(),
                 department: $('#department').val(),
                 studentId: $('#studentId').val(),
-                gender: $('#gender').val(),
-                birthday: $('#birthday').val(),
-                email: $('#email').val()
+                gender: $('#gender').val()
             };
 
             $.ajax({


### PR DESCRIPTION
## 이슈 번호
Close #9 

## 개요
- Message 엔티티 복합키에서 단일키로 변경
- redis 도입
- Message 관리 로직 구현

## 작업사항
### 1️⃣ Message 엔티티 복합키에서 단일키로 변경
- 복합키에서는 @GeneratedValue, auto increment를 사용할 수 없음
- chatroom 내에서만 고유한 id를 생성하는 로직은 db를 조회하여 해당 채팅방에서 가장 최근에 발급한 message id를 조회한 후, 새로운 Message 객체에 +1한 값을 id로 부여한 다음, 그 Message 객체를 DB에 save 해야하는데
  이 사이에 다른 message가 생성되면 순서가 깨질 수 있으니 synchronized 블럭을 사용하여 동기화해주거나 데이터베이스를 잠금해야 한다. 이는 애플리케이션의 성능을 크게 떨어뜨릴 것이라 생각하여 우선은 message id만 단일키로 사용하기로 결정했다.
🚨 나중에 noSQL을 도입하며 id 발급 방법에 대해 더 자세히 생각해보기!! 🚨

### 2️⃣ redis 도입
1. ValueOperations `"refreshToken: {memberId}" : "{refreshToken}"`
  회원가입 시, 혹은 refresh token이 재발급될 때마다 redis에 refresh token을 저장하여 조회, 접근 시간을 줄인다.

3. ValueOperations`"session: {memberId}" : "{sessionId}"`
   회원가입 시, 혹은 web socket 서버와 연결이 끊겨 오류가 발생할 때마다 web socket 서버에 연결 요청을 보냄. 연결이 성공적으로 되고 WebSocketSession이 생성되면 WebSocketHandler에는 `Map<Long memberId, WebSocketSession session>` 을 저장한 후 레디스에 member id - session id 쌍을 저장한다.

5. HashOperations ` "chatroomId : {id}"  - "{memberId}" : "{세션 id}" 
                                                                      - "{memberId}" : "{세션 id}"`
   chatroom 에 누군가가 join/leave할 때마다 chatroom id로 hashMap을 조회 -> Map<Long memberId, String sessionId> 쌍을 추가/제거한다.

### 3️⃣ Message 관리 로직 구현
1. 클라이언트가 TextMessage 전송
3. TextMessage를 ChatMessage(dto)로 변환
5. Message (엔티티) 객체로 변환하여 repository에 저장
6. 저장이 완료되면 다른 사용자들에게도 전송

- sql 쿼리문이 나가는 횟수 : 총 3회
  1. chatroom id로 채팅방 조회 : chatroomRepository.findById
  2. messageType이 REPLY 이거나 TRANSLATE 인 경우, message id로 메세지 조회 : messageRepository.findById
  3. Message 객체 저장 : messageRepository.save
