### PR TITLE
[Closes #28] 프로필 관련 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@
 
 ### 📒 Domain Conceptual Diagram
 <img width="1184" alt="Image" src="https://github.com/user-attachments/assets/4405ec8d-240b-4ff1-bcef-46954e31963d" />
+
+### 커밋 메시지 컨벤션
+- feat : 새로운 기능 추가 
+- fix : 버그 수정 
+- docs : 문서 수정 
+- style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우 
+- refactor : 코드 리펙토링 
+- test : 테스트 코드, 리펙토링 테스트 코드 추가 
+- chore : 빌드 업무 수정, 패키지 매니저 수정

--- a/src/main/java/kuchat/server/common/config/S3Config.java
+++ b/src/main/java/kuchat/server/common/config/S3Config.java
@@ -1,0 +1,30 @@
+package kuchat.server.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client(){
+        BasicAWSCredentials AWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(AWSCredentials))
+                .build();
+    }
+}

--- a/src/main/java/kuchat/server/common/config/WebMvcConfig.java
+++ b/src/main/java/kuchat/server/common/config/WebMvcConfig.java
@@ -54,7 +54,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         log.info("[addCorsMappings] CorsMapping 호출");
         registry.addMapping("/**")
-                .allowedOrigins("https://kuchat.netlify.app", "http://localhost:9000", "https://www.kuchat.site")
+                .allowedOrigins("https://kuchat.netlify.app", "https://www.kuchat.site")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH","OPTIONS")
                 .exposedHeaders("location", "Authorization")
                 .allowedHeaders("Content-Type", "Authorization", "X-Requested-With", "Accept")

--- a/src/main/java/kuchat/server/common/exception/ImageControllerAdvice.java
+++ b/src/main/java/kuchat/server/common/exception/ImageControllerAdvice.java
@@ -1,0 +1,35 @@
+package kuchat.server.common.exception;
+
+import kuchat.server.common.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_IMAGE;
+import static kuchat.server.common.response.BaseResponseStatus.OVER_SIZE_IMAGE;
+
+@Slf4j
+@RestControllerAdvice
+public class ImageControllerAdvice {
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse> handleMissingImageException(MissingServletRequestParameterException e) {
+        // 클라이언트에서 multipartFile 필드 이름을 잘못 지정했거나, 파일 자체를 전송하지 않은 경우
+
+        log.error("[handleMissingImageException] 클라이언트 요청에서 multipartFile이 누락된 경우");
+        HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(NOT_FOUND_IMAGE));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<BaseResponse> handleUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.error("[handleUploadSizeExceededException] 파일의 용량이 초과된 경우");
+        HttpStatus httpStatus = OVER_SIZE_IMAGE.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(OVER_SIZE_IMAGE));
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/KuchatException.java
+++ b/src/main/java/kuchat/server/common/exception/KuchatException.java
@@ -1,6 +1,5 @@
 package kuchat.server.common.exception;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.common.response.SimpleErrorResponse;

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -43,6 +43,8 @@ public enum BaseResponseStatus {
     NOT_FOUND_IMAGE(4011, HttpStatus.BAD_REQUEST, "요청에서 이미지 파일을 찾을 수 없습니다. 다시 시도해주세요."),
     OVER_SIZE_IMAGE(4012, HttpStatus.BAD_REQUEST, "이미지 파일이 용량을 초과하여 업로드할 수 없습니다. 업로드 가능한 크기는 최대 10MB 입니다."),
 
+
+
     //- 5000번대 : 채팅방(chatroom) 관련 코드
     NOT_FOUND_CHATROOM(5000, HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
     EXIT_CHATROOM_FAIL(5001, HttpStatus.INTERNAL_SERVER_ERROR, "채팅방 나가기에 실패했습니다."),
@@ -65,21 +67,14 @@ public enum BaseResponseStatus {
     NOT_FOUND_SESSION(6008, HttpStatus.NOT_FOUND, "사용자의 웹소켓 세션이 존재하지 않습니다. 다시 연결을 시도해주세요."),
 
     //- 7000번대 : 친구 관련 코드
-//    FRIEND_APPLY_SUCCESS(000, HttpStatus.OK, "친구 신청 성공"),
-//    FRIEND_ACCEPT_SUCCESS(6001, HttpStatus.CREATED, "친구 신청 수락 성공"),
-//    FRIEND_APPLY_REFUSE_SUCCESS(6002, HttpStatus.OK, "친구 신청 거절 성공"),
-//    FRIEND_APPLY_LOOKUP_SUCCESS(6003, HttpStatus.OK, "친구 신청 목록 조회 성공"),
-//    FRIEND_DELETE_SUCCESS(6004, HttpStatus.OK, "친구 삭제 성공"),
-//    BLOCK_MEMBER_SUCCESS(6005, HttpStatus.OK, "사용자 차단 성공"),
-//    RELEASE_BLOCK_SUCCESS(6006, HttpStatus.OK, "차단 해제 성공"),
-//    BLOCK_LOOKUP_SUCCESS(6007, HttpStatus.OK, "차단 목록 조회 성공"),
+//    NOT_FOUND_FRIENDSHIP(7000, HttpStatus.NOT_FOUND, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
+    BLOCKED_MEMBER(7000, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
 
-    ALREADY_APPLY(7000, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
-    NOT_FOUND_FRIEND(7001, HttpStatus.NOT_FOUND, "친구가 아닌 사용자입니다."),
-    NOT_FOUND_PLUSID(7002, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
-    NOT_FOUND_BLOCK(7003, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
-    BLOCKED_MEMBER(7004, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
-    ALREADY_FRIEND(7005, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
+    ALREADY_APPLY(70, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
+    NOT_FOUND_FRIEND(70, HttpStatus.NOT_FOUND, "친구가 아닌 사용자입니다."),
+    NOT_FOUND_PLUSID(70, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
+    NOT_FOUND_BLOCK(70, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
+    ALREADY_FRIEND(70, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
 
     //- 8000번대 : 알림 관련 코드
 

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -40,7 +40,8 @@ public enum BaseResponseStatus {
     DATE_BAD_REQUEST(4008, HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식에 맞게 다시 입력해주세요."),
     IMAGE_BAD_REQUEST(4009, HttpStatus.BAD_REQUEST, "이미지 업로드 요청 방식이 올바르지 않습니다. 다시 시도해주세요."),
     IMAGE_UPLOAD_FAIL(4010, HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다. 다시 시도해주세요."),
-    DUPLICATED_IMAGE(4011, HttpStatus.BAD_REQUEST, "기존에 업로"),
+    NOT_FOUND_IMAGE(4011, HttpStatus.BAD_REQUEST, "요청에서 이미지 파일을 찾을 수 없습니다. 다시 시도해주세요."),
+    OVER_SIZE_IMAGE(4012, HttpStatus.BAD_REQUEST, "이미지 파일이 용량을 초과하여 업로드할 수 없습니다. 업로드 가능한 크기는 최대 10MB 입니다."),
 
     //- 5000번대 : 채팅방(chatroom) 관련 코드
     NOT_FOUND_CHATROOM(5000, HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -38,7 +38,9 @@ public enum BaseResponseStatus {
     NOT_SIGNUP_MEMBER(4006, HttpStatus.UNAUTHORIZED, "아직 회원가입 하지 않은 회원입니다. 회원가입 페이지로 이동해 주세요."),
     NOT_FOUND_STATUS(4007, HttpStatus.NOT_FOUND, "사용자 계정 상태가 유효하지 않습니다. 다시 시도해주세요."),
     DATE_BAD_REQUEST(4008, HttpStatus.BAD_REQUEST, "날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식에 맞게 다시 입력해주세요."),
-
+    IMAGE_BAD_REQUEST(4009, HttpStatus.BAD_REQUEST, "이미지 업로드 요청 방식이 올바르지 않습니다. 다시 시도해주세요."),
+    IMAGE_UPLOAD_FAIL(4010, HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다. 다시 시도해주세요."),
+    DUPLICATED_IMAGE(4011, HttpStatus.BAD_REQUEST, "기존에 업로"),
 
     //- 5000번대 : 채팅방(chatroom) 관련 코드
     NOT_FOUND_CHATROOM(5000, HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/src/main/java/kuchat/server/domain/S3Service.java
+++ b/src/main/java/kuchat/server/domain/S3Service.java
@@ -1,0 +1,32 @@
+package kuchat.server.domain;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URL;
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private long accessExpiration = 1000 * 60 * 60;     // 1시간 조회 가능
+
+    public String generatePresignedUrl(String objectKey){
+        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucketName, objectKey)
+                .withMethod(HttpMethod.GET)
+                .withExpiration(new Date(System.currentTimeMillis() + accessExpiration));
+        URL url = amazonS3.generatePresignedUrl(request);
+        return url.toString();
+    }
+}

--- a/src/main/java/kuchat/server/domain/S3Service.java
+++ b/src/main/java/kuchat/server/domain/S3Service.java
@@ -1,15 +1,26 @@
 package kuchat.server.domain;
 
-import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import kuchat.server.common.exception.KuchatException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URL;
-import java.util.Date;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static kuchat.server.common.response.BaseResponseStatus.IMAGE_BAD_REQUEST;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,13 +31,53 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucketName;
 
-    private long accessExpiration = 1000 * 60 * 60;     // 1시간 조회 가능
+    public String uploadImage(MultipartFile multipartFile, String dirName) throws IOException {
+        log.info("[uploadImage] 이미지 업로드 요청");
+        File file = convertToFile(multipartFile)
+                .orElseThrow(() -> new KuchatException(IMAGE_BAD_REQUEST));
+        return putS3(dirName, file);
+    }
 
-    public String generatePresignedUrl(String objectKey){
-        GeneratePresignedUrlRequest request = new GeneratePresignedUrlRequest(bucketName, objectKey)
-                .withMethod(HttpMethod.GET)
-                .withExpiration(new Date(System.currentTimeMillis() + accessExpiration));
-        URL url = amazonS3.generatePresignedUrl(request);
-        return url.toString();
+    private String putS3(String dirName, File file) {
+        String fileName = createFilePath(dirName, file);
+        amazonS3.putObject(new PutObjectRequest(bucketName, fileName, file).withCannedAcl(CannedAccessControlList.PublicRead));
+        file.delete();
+        return amazonS3.getUrl(bucketName, fileName).toString();
+    }
+
+    private String createFilePath(String dirName, File file) {
+        LocalDateTime uploadTime = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH-mm-ss");
+        String formattedUploadTime = uploadTime.format(formatter);
+        String fileName = getFileName(file);
+
+        return dirName + "/" + formattedUploadTime + "_" + fileName;
+    }
+
+    private String getFileName(File file) {
+        String sanitizeFileName = file.getName().replaceAll("[^a-zA-Z0-9_-]", "");
+        if (sanitizeFileName.isBlank() || sanitizeFileName.length() < 5){
+            sanitizeFileName = UUID.randomUUID().toString();
+        }
+        return sanitizeFileName;
+    }
+
+    private Optional<File> convertToFile(MultipartFile multipartFile) throws IOException {
+        log.info("[converToFile] multipartFile을 File로 변경");
+        File convertFile = new File(Objects.requireNonNull(multipartFile.getOriginalFilename()));
+        try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+            fos.write(multipartFile.getBytes());
+        }
+        return Optional.of(convertFile);
+    }
+
+
+    public void deleteImage(String imageUrl) {
+        log.info("[deleteImage] 우리 서버의 S3 올라가있는 기존 이미지만 삭제");
+        if (imageUrl.startsWith("https://" + bucketName + ".s3")) {
+            String splitStr = "./com";
+            String fileName = imageUrl.substring(imageUrl.lastIndexOf(splitStr) + splitStr.length());
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, fileName));
+        }
     }
 }

--- a/src/main/java/kuchat/server/domain/block/repository/BlockRepository.java
+++ b/src/main/java/kuchat/server/domain/block/repository/BlockRepository.java
@@ -3,6 +3,8 @@ package kuchat.server.domain.block.repository;
 import kuchat.server.domain.block.Block;
 import kuchat.server.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +14,8 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     Optional<Block> findByBlockerAndBlocked(Member blocker, Member blocked);
 
     List<Block> findByBlocker(Member member);
+
+    @Query("select b from Block b " +
+            "where (b.blocked.id = :id1 and b.blocker.id = :id2) or (b.blocked.id = :id2 and b.blocker.id = :id1)")
+    Optional<Block> findByIds(@Param("id1") Long member1Id, @Param("id2") Long member2Id);
 }

--- a/src/main/java/kuchat/server/domain/block/service/BlockService.java
+++ b/src/main/java/kuchat/server/domain/block/service/BlockService.java
@@ -70,9 +70,8 @@ public class BlockService {
                 .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
     }
 
-    public boolean isBlockOrBlocked(Member member1, Member member2){
-        Optional<Block> byMembers1 = blockRepository.findByBlockerAndBlocked(member1, member2);
-        Optional<Block> byMembers2 = blockRepository.findByBlockerAndBlocked(member2, member2);
-        return byMembers1.isPresent() || byMembers2.isPresent();
+    public boolean isBlockOrBlocked(Long member1Id, Long member2Id){
+        Optional<Block> optionalBlock = blockRepository.findByIds(member1Id, member2Id);
+        return optionalBlock.isPresent();
     }
 }

--- a/src/main/java/kuchat/server/domain/friend/Friend.java
+++ b/src/main/java/kuchat/server/domain/friend/Friend.java
@@ -1,6 +1,7 @@
 package kuchat.server.domain.friend;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.member.Member;
 import lombok.Builder;
@@ -19,18 +20,21 @@ public class Friend extends BaseTime {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "friend_member_id")      // 팔로우 당한 사람 (친구)
-    private Member followed;
+    @JoinColumn(name = "sender_id")            // 팔로우한 사람
+    private Member sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "follower_id")            // 팔로우한 사람 (자기 자신)
-    private Member follower;
+    @JoinColumn(name = "receiver_id")           // 팔로우 당한 사람
+    private Member receiver;
+
+    @Column(nullable = false)
+    private boolean acceptance = false;
 
 
     @Builder
-    public Friend(Member follower, Member followed) {
-        this.follower = follower;
-        this.followed = followed;
+    public Friend(Member sender, Member receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
     }
 
 }

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -54,7 +54,7 @@ public class FriendController {
     public ResponseEntity<FriendResponse> getFriendProfile(@Auth Member member,
                                                            @PathVariable("id") Long friendId) {
         log.info("[getFriendProfile] id = {} 인 사용자의 프로필 조회 요청", friendId);
-        FriendResponse response = friendService.getFriendProfile(member, friendId);
+        FriendResponse response = friendService.getFriendProfile(member.getId(), friendId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -12,10 +12,10 @@ import java.util.Optional;
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("select f from Friend f " +
-            "where (f.follower = :member and f.followed.profile.name like %:name%)")
+            "where (f.sender = :member and f.receiver.profile.name like %:name%)")
     List<Friend> findAllByName(@Param("member") Member member, @Param("name") String name);       // member 의 친구들 검색
 
     @Query("select f from Friend f " +
-            "where (f.follower = :follower and f.followed = :followed)")
-    Optional<Friend> findByMembers(@Param("follower") Member follower, @Param("followed") Member followed);
+            "where (f.sender = :sender and f.receiver = :receiver)")
+    Optional<Friend> findByMembers(@Param("sender") Member follower, @Param("receiver") Member receiver);
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -35,8 +35,8 @@ public class FriendService {
         Member friendMember = memberRepository.findById(friendId)
                 .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_MEMBER));
         Friend newFriend = Friend.builder()
-                .follower(member)
-                .followed(friendMember).build();
+                .sender(member)
+                .receiver(friendMember).build();
         friendRepository.save(newFriend);
     }
 
@@ -46,8 +46,8 @@ public class FriendService {
         Member friendMember = memberRepository.findByPlusId(plusId)
                 .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
         Friend newFriend = Friend.builder()
-                .follower(member)
-                .followed(friendMember).build();
+                .sender(member)
+                .receiver(friendMember).build();
         friendRepository.save(newFriend);
     }
 
@@ -55,7 +55,7 @@ public class FriendService {
         log.info("[getFriendList] 이름에 '{}' 을 포함하는 친구 조회", friendName);
         List<Friend> friendships = friendRepository.findAllByName(member, friendName);
         List<FriendResponse> friendResponse = friendships.stream()
-                .map(Friend::getFollowed)
+                .map(Friend::getReceiver)
                 .map(FriendResponse::new)
                 .toList();
         return new FriendResponses(friendResponse);

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -61,15 +61,13 @@ public class FriendService {
         return new FriendResponses(friendResponse);
     }
 
-    public FriendResponse getFriendProfile(Member member, Long friendId) {
+    public FriendResponse getFriendProfile(Long memberId, Long friendId) {
         log.info("[getFriendProfile] id가 {} 인 친구의 프로필 조회", friendId);
-        Member friendMember = getMember(friendId);
-        // friendId인 멤버를 1. 내가 차단했거나, 2. 상대가 나를 차단한 경우
-        // 예외가 발생해야 한다.
-
-        if (blockService.isBlockOrBlocked(member, friendMember)) {
+        // friendId인 멤버를 1. 내가 차단했거나, 2. 상대가 나를 차단한 경우 예외가 발생해야 한다.
+        if (blockService.isBlockOrBlocked(memberId, friendId)) {
             throw new KuchatException(BLOCKED_MEMBER);
         }
+        Member friendMember = getMember(friendId);
         return new FriendResponse(friendMember);
     }
 

--- a/src/main/java/kuchat/server/domain/member/Language.java
+++ b/src/main/java/kuchat/server/domain/member/Language.java
@@ -47,7 +47,9 @@ public class Language {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Language language = (Language) o;
-        return getSetLanguage() == language.getSetLanguage() && getFirstLanguage() == language.getFirstLanguage() && getSecondLanguage() == language.getSecondLanguage();
+        return getSetLanguage() == language.getSetLanguage() &&
+                getFirstLanguage() == language.getFirstLanguage() &&
+                getSecondLanguage() == language.getSecondLanguage();
     }
 
     @Override

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -94,8 +94,8 @@ public class Member extends BaseTime {
         return stringBuilder.toString();
     }
 
-    public void updateProfile(ProfileUpdateRequest request) {
-        profile.update(request);
+    public void updateProfile(ProfileUpdateRequest request, String defaultImage) {
+        profile.update(request, defaultImage);
         language.update(request);
     }
 

--- a/src/main/java/kuchat/server/domain/member/Member.java
+++ b/src/main/java/kuchat/server/domain/member/Member.java
@@ -102,4 +102,8 @@ public class Member extends BaseTime {
     public String getName() {
         return profile.getName();
     }
+
+    public void updateProfileImage(String newProfile) {
+        profile.updateProfileImage(newProfile);
+    }
 }

--- a/src/main/java/kuchat/server/domain/member/Profile.java
+++ b/src/main/java/kuchat/server/domain/member/Profile.java
@@ -52,10 +52,14 @@ public class Profile {
         this.birthday = request.getBirth();
     }
 
-    public void update(ProfileUpdateRequest request) {
+    public void update(ProfileUpdateRequest request, String defaultImage) {
         name = request.getName();
         department = request.getDepartment();
         aboutMe = request.getAboutMe();
+        String profileImage = getProfileImage();
+        if (profileImage == null || profileImage.isBlank()){
+            this.profileImage = defaultImage;
+        }
     }
 
     public int getAge() {

--- a/src/main/java/kuchat/server/domain/member/Profile.java
+++ b/src/main/java/kuchat/server/domain/member/Profile.java
@@ -73,11 +73,21 @@ public class Profile {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Profile profile = (Profile) o;
-        return Objects.equals(getName(), profile.getName()) && Objects.equals(getDepartment(), profile.getDepartment()) && Objects.equals(getBirthday(), profile.getBirthday()) && getGender() == profile.getGender() && Objects.equals(getHometown(), profile.getHometown()) && Objects.equals(getProfileImage(), profile.getProfileImage()) && Objects.equals(getAboutMe(), profile.getAboutMe());
+        return Objects.equals(getName(), profile.getName()) &&
+                Objects.equals(getDepartment(), profile.getDepartment()) &&
+                Objects.equals(getBirthday(), profile.getBirthday()) &&
+                getGender() == profile.getGender() &&
+                Objects.equals(getHometown(), profile.getHometown()) &&
+                Objects.equals(getProfileImage(), profile.getProfileImage()) &&
+                Objects.equals(getAboutMe(), profile.getAboutMe());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(getName(), getDepartment(), getBirthday(), getGender(), getHometown(), getProfileImage(), getAboutMe());
+    }
+
+    public void updateProfileImage(String newProfile) {
+        this.profileImage = newProfile;
     }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
@@ -54,4 +54,14 @@ public class ProfileController {
         log.info("[updateMyProfileImage] 프로필 이미지 수정 요청 = {}", multipartFile.toString());
         return profileService.updateProfileImage(member, multipartFile);
     }
+
+    @Operation(summary = "친구의 프로필 조회")
+    @SecurityRequirement(name = "JWT")
+    @GetMapping("/{memberId}")
+    public ResponseEntity<BaseResponse> getFriendProfile(@Auth Member member,
+                                                         @PathVariable("memberId") Long friendMemberId) {
+        log.info("[getFriendProfile] 친구의 프로필 조회 요청 : memberId = {}, 친구의 memberId = {}",
+                member.getId(), friendMemberId);
+        return profileService.getFriendProfile(member, friendMemberId);
+    }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
@@ -43,7 +43,7 @@ public class ProfileController {
                                                         BindingResult bindingResult) {
         log.info("[updateMyProfile] 프로필 수정 요청 = {}", requestBody.toString());
         Validator.validateRequest(bindingResult);
-        return profileService.updateProfile(member.getId(), requestBody);
+        return profileService.updateProfile(member, requestBody);
     }
 
     @Operation(summary = "나의 프로필 사진 수정")
@@ -62,6 +62,6 @@ public class ProfileController {
                                                          @PathVariable("memberId") Long friendMemberId) {
         log.info("[getFriendProfile] 친구의 프로필 조회 요청 : memberId = {}, 친구의 memberId = {}",
                 member.getId(), friendMemberId);
-        return profileService.getFriendProfile(member, friendMemberId);
+        return profileService.getFriendProfile(member.getId(), friendMemberId);
     }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kuchat.server.common.jwt.argumentResolver.Auth;
 import kuchat.server.common.response.BaseResponse;
-import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.Validator;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
@@ -17,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Tag(name = "Profile", description = "프로필")
@@ -44,5 +44,14 @@ public class ProfileController {
         log.info("[updateMyProfile] 프로필 수정 요청 = {}", requestBody.toString());
         Validator.validateRequest(bindingResult);
         return profileService.updateProfile(member.getId(), requestBody);
+    }
+
+    @Operation(summary = "나의 프로필 사진 수정")
+    @SecurityRequirement(name = "JWT")
+    @PutMapping("/image")
+    public ResponseEntity<BaseResponse> updateMyProfileImage(@Auth Member member,
+                                                        @RequestParam MultipartFile multipartFile) {
+        log.info("[updateMyProfileImage] 프로필 이미지 수정 요청 = {}", multipartFile.toString());
+        return profileService.updateProfileImage(member, multipartFile);
     }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kuchat.server.common.jwt.argumentResolver.Auth;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.Validator;
 import kuchat.server.domain.member.Member;
@@ -37,12 +38,11 @@ public class ProfileController {
     @Operation(summary = "나의 프로필 수정")
     @SecurityRequirement(name = "JWT")
     @PutMapping
-    public ResponseEntity<BaseResponseStatus> updateMyProfile(@Auth Member member,
-                                                              @Validated @RequestBody ProfileUpdateRequest requestBody,
-                                                              BindingResult bindingResult) {
+    public ResponseEntity<BaseResponse> updateMyProfile(@Auth Member member,
+                                                        @Validated @RequestBody ProfileUpdateRequest requestBody,
+                                                        BindingResult bindingResult) {
         log.info("[updateMyProfile] 프로필 수정 요청 = {}", requestBody.toString());
         Validator.validateRequest(bindingResult);
-        profileService.updateProfile(member.getId(), requestBody);
-        return ResponseEntity.ok(BaseResponseStatus.SUCCESS);
+        return profileService.updateProfile(member.getId(), requestBody);
     }
 }

--- a/src/main/java/kuchat/server/domain/member/dto/ProfileImageUpdateResponse.java
+++ b/src/main/java/kuchat/server/domain/member/dto/ProfileImageUpdateResponse.java
@@ -1,0 +1,23 @@
+package kuchat.server.domain.member.dto;
+
+import kuchat.server.common.response.BaseResponse;
+import kuchat.server.common.response.BaseResponseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@ToString
+@Slf4j
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileImageUpdateResponse extends BaseResponse {
+    private String newProfileImage;
+
+    public ProfileImageUpdateResponse(BaseResponseStatus baseResponseStatus, String newProfile) {
+        super(baseResponseStatus);
+        this.newProfileImage = newProfile;
+    }
+}

--- a/src/main/java/kuchat/server/domain/member/dto/ProfileResponse.java
+++ b/src/main/java/kuchat/server/domain/member/dto/ProfileResponse.java
@@ -1,6 +1,5 @@
 package kuchat.server.domain.member.dto;
 
-import kuchat.server.domain.enums.Gender;
 import kuchat.server.domain.member.Profile;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,10 +23,7 @@ public class ProfileResponse {
 
     public ProfileResponse(Profile profile) {
         this.name = profile.getName();
-        Gender gender1 = profile.getGender();
-        log.info("[ProfileResponse] gender ="+gender1);
         this.gender = profile.getGender().getKorean();
-        log.info("[ProfileResponse] gender" + this.gender);
         this.age = profile.getAge();
         this.department = profile.getDepartment();
         this.hometown = profile.getHometown();

--- a/src/main/java/kuchat/server/domain/member/dto/ProfileUpdateRequest.java
+++ b/src/main/java/kuchat/server/domain/member/dto/ProfileUpdateRequest.java
@@ -22,6 +22,8 @@ public class ProfileUpdateRequest {
     @NotBlank
     private String department;
 
+    private String profileImage;
+
     private String aboutMe;
 
 }

--- a/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
+++ b/src/main/java/kuchat/server/domain/member/dto/SignupRequest.java
@@ -1,6 +1,7 @@
 package kuchat.server.domain.member.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 
@@ -21,12 +22,14 @@ public class SignupRequest {
     @NotBlank
     private String country;
 
+    @NotNull
     @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "이름은 최소 2자 이상, 20자 이하이며, 영문/한글/숫자만 입력 가능합니다.")
     private String name;
 
     @NotBlank
     private String major;
 
+    @NotNull
     @Pattern(regexp = "^[0-9]{9}$", message = "학번은 9자리 숫자여야 합니다.")
     private String studentIdNumber;
 

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -53,6 +53,7 @@ public class MemberService {
     }
 
     private void validateStudentId(String studentId) {
+        log.info("[validateStudentId] 학번 = {}", studentId);
         memberRepository.findByStudentId(studentId).ifPresent(member -> {
             log.error("[error] 이미 존재하는 학번입니다.");
             throw new KuchatException(DUPLICATED_STUDENT_ID);

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -43,9 +43,8 @@ public class ProfileService {
     }
 
     @Transactional
-    public ResponseEntity<BaseResponse> updateProfile(Long memberId, ProfileUpdateRequest request) {
-        Member member = getMember(memberId);
-        validateAndUpdatePlusId(memberId, request.getPlusId());
+    public ResponseEntity<BaseResponse> updateProfile(Member member, ProfileUpdateRequest request) {
+        validateAndUpdatePlusId(member.getId(), request.getPlusId());
         member.updateProfile(request, defaultImage);
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
@@ -84,9 +83,9 @@ public class ProfileService {
                 );
     }
 
-    public ResponseEntity<BaseResponse> getFriendProfile(Member member, Long friendMemberId) {
+    public ResponseEntity<BaseResponse> getFriendProfile(Long memberId, Long friendMemberId) {
         Member friend = getMember(friendMemberId);
-        if (blockService.isBlockOrBlocked(member, friend)) {
+        if (blockService.isBlockOrBlocked(memberId, friendMemberId)) {
             throw new KuchatException(new BaseResponse(BLOCKED_MEMBER));
         }
         DetailProfileResponse friendProfileResponse = new DetailProfileResponse(friend);

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -2,18 +2,19 @@ package kuchat.server.domain.member.service;
 
 import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.jwt.JwtTokenService;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
 import kuchat.server.domain.member.dto.ProfileUpdateRequest;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static kuchat.server.common.response.BaseResponseStatus.DUPLICATED_PLUSID;
-import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_MEMBER;
+import static kuchat.server.common.response.BaseResponseStatus.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,15 +23,19 @@ import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_MEMBER;
 public class ProfileService {
     private final MemberRepository memberRepository;
 
+    @Value("${default.image.address}")
+    private String defaultImage;
+
     public ResponseEntity<DetailProfileResponse> getProfile(Member member) {
         return ResponseEntity.ok(new DetailProfileResponse(member));
     }
 
     @Transactional
-    public void updateProfile(Long memberId, ProfileUpdateRequest request) {
+    public ResponseEntity<BaseResponse> updateProfile(Long memberId, ProfileUpdateRequest request) {
         Member member = getMember(memberId);
         validateAndUpdatePlusId(memberId, request.getPlusId());
-        member.updateProfile(request);
+        member.updateProfile(request, defaultImage);
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
     private void validateAndUpdatePlusId(Long memberId, String plusId) {

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -3,6 +3,8 @@ package kuchat.server.domain.member.service;
 import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.S3Service;
+import kuchat.server.domain.block.service.BlockService;
+import kuchat.server.domain.friend.repository.FriendRepository;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
 import kuchat.server.domain.member.dto.ProfileImageUpdateResponse;
@@ -27,6 +29,7 @@ import static kuchat.server.common.response.BaseResponseStatus.*;
 @Service
 public class ProfileService {
     private final MemberRepository memberRepository;
+    private final BlockService blockService;
     private final S3Service s3Service;
 
     @Value("${default.profile.address}")
@@ -79,6 +82,15 @@ public class ProfileService {
                         },
                         () -> member.setPlusId(plusId)
                 );
+    }
+
+    public ResponseEntity<BaseResponse> getFriendProfile(Member member, Long friendMemberId) {
+        Member friend = getMember(friendMemberId);
+        if (blockService.isBlockOrBlocked(member, friend)) {
+            throw new KuchatException(new BaseResponse(BLOCKED_MEMBER));
+        }
+        DetailProfileResponse friendProfileResponse = new DetailProfileResponse(friend);
+        return ResponseEntity.ok(friendProfileResponse);
     }
 
     private Member getMember(Long memberId) {

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -1,18 +1,23 @@
 package kuchat.server.domain.member.service;
 
 import kuchat.server.common.exception.KuchatException;
-import kuchat.server.common.jwt.JwtTokenService;
 import kuchat.server.common.response.BaseResponse;
+import kuchat.server.domain.S3Service;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
+import kuchat.server.domain.member.dto.ProfileImageUpdateResponse;
 import kuchat.server.domain.member.dto.ProfileUpdateRequest;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
 
@@ -22,9 +27,13 @@ import static kuchat.server.common.response.BaseResponseStatus.*;
 @Service
 public class ProfileService {
     private final MemberRepository memberRepository;
+    private final S3Service s3Service;
 
-    @Value("${default.image.address}")
+    @Value("${default.profile.address}")
     private String defaultImage;
+
+    @Value("${default.profile.dirName}")
+    private String profileImageDirName;
 
     public ResponseEntity<DetailProfileResponse> getProfile(Member member) {
         return ResponseEntity.ok(new DetailProfileResponse(member));
@@ -38,13 +47,33 @@ public class ProfileService {
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
+    @Transactional
+    public ResponseEntity<BaseResponse> updateProfileImage(Member member, MultipartFile multipartFile) {
+        String oldProfile = member.getProfile().getProfileImage();
+        log.info("[updateProfileImage] 기존 이미지 = {}", oldProfile);
+        String newProfile = uploadAndUpdateImage(member, multipartFile);
+        s3Service.deleteImage(oldProfile);
+        return ResponseEntity.ok(new ProfileImageUpdateResponse(SUCCESS, newProfile));
+    }
+
+    private String uploadAndUpdateImage(Member member, MultipartFile multipartFile) {
+        try {
+            String newProfile = s3Service.uploadImage(multipartFile, profileImageDirName);
+            log.info("[updateProfileImage] 새로운 이미지 = {}", newProfile);
+            member.updateProfileImage(newProfile);
+            return newProfile;
+        } catch (IOException e) {
+            throw new KuchatException(IMAGE_UPLOAD_FAIL);
+        }
+    }
+
     private void validateAndUpdatePlusId(Long memberId, String plusId) {
         Member member = getMember(memberId);
         memberRepository.findAllByPlusIdWithLock(plusId)
                 .stream().findAny()
                 .ifPresentOrElse(
                         duplicatedMember -> {
-                            if(!duplicatedMember.equals(member)){
+                            if (!duplicatedMember.equals(member)) {
                                 throw new KuchatException(DUPLICATED_PLUSID);
                             }
                         },


### PR DESCRIPTION
## 이슈 번호
Close #28 

## 개요
- 내 프로필 조회
- 내 프로필 정보 수정
- 내 프로필 사진 업로드 후 기존 이미지 제거
- 친구 프로필 조회

## 작업사항
### 1. 내 프로필 조회
- 사용자 요청에 있는 토큰을 통해 Member 조회 시 1번

### 2. 내 프로필 정보 수정
- 사용자 요청에 있는 토큰을 통해 Member 조회 시 1번
- 중복되는 plus id가 있는지 확인하기 위한 Member 테이블 조회 1번
- 트랜잭션 종료 후 변경 감지를 통해 Member 프로필 정보 변경 쿼리 1번
⇒ 총 3회

### 3. 내 프로필 사진 업로드 후 기존 이미지 제거
- 사용자 요청에 있는 토큰을 통해 Member 조회 시 1번
- 트랜잭션 종료 후 변경 감지를 통해 Member 프로필 사진 변경 쿼리 1번
⇒ 총 2회

### 4. 친구 프로필 조회
- 사용자 요청에 있는 토큰을 통해 Member 조회 시 1번
- 친구의 id로 차단 관계 조회 1번
- 친구의 Member 객체 조회 1번
⇒ 총 3회