### PR TITLE
[Closes #29] 친구 관련 기본 기능 구현

### DIFF
--- a/src/main/java/kuchat/server/common/exception/JwtControllerAdvice.java
+++ b/src/main/java/kuchat/server/common/exception/JwtControllerAdvice.java
@@ -1,0 +1,41 @@
+package kuchat.server.common.exception;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import kuchat.server.common.response.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static kuchat.server.common.response.BaseResponseStatus.*;
+
+@Slf4j
+@RestControllerAdvice
+public class JwtControllerAdvice {
+
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<BaseResponse> handleExpiredJwtException(ExpiredJwtException e) {
+        log.error("[handleExpiredJwtException] 만료된 jwt 토큰입니다. 다시 로그인해주세요.");
+        HttpStatus httpStatus = EXPIRED_TOKEN.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(EXPIRED_TOKEN));
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity<BaseResponse> handleMalformedJwtException(MalformedJwtException e) {
+        log.error("[handleMalformedJwtException] 올바르게 구성되지 않은 jwt 토큰입니다.");
+        HttpStatus httpStatus = MALFORMED_TOKEN.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(MALFORMED_TOKEN));
+    }
+    @ExceptionHandler(JwtException.class)
+    public ResponseEntity<BaseResponse> handleJwtException(JwtException e) {
+        log.error("[handleJwtException] jwt 토큰 오류입니다.");
+        HttpStatus httpStatus = INVALID_TOKEN.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(INVALID_TOKEN));
+    }
+}

--- a/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
+++ b/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
@@ -4,6 +4,7 @@ import kuchat.server.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -37,5 +38,13 @@ public class RequestControllerAdvice {
         HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
         return ResponseEntity.status(httpStatus)
                 .body(new BaseResponse(NOT_FOUND_IMAGE));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<BaseResponse> handleMissingPathVariableException(HttpRequestMethodNotSupportedException e){
+        log.error("[handleMissingPathVariableException] 요청 url에서 path variable이 누락된 경우");
+        HttpStatus httpStatus = PATH_VARIABLE_NOT_FOUND.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(PATH_VARIABLE_NOT_FOUND));
     }
 }

--- a/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
+++ b/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
 
@@ -35,6 +36,7 @@ public class RequestControllerAdvice {
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<BaseResponse> handleMissingMultipartException(MultipartException e) {
         log.error("[handleMissingMultipartException] 파일의 용량이 초과된 경우");
+        log.error(e.getMessage());
         HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
         return ResponseEntity.status(httpStatus)
                 .body(new BaseResponse(NOT_FOUND_IMAGE));
@@ -43,8 +45,19 @@ public class RequestControllerAdvice {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     public ResponseEntity<BaseResponse> handleMissingPathVariableException(HttpRequestMethodNotSupportedException e){
         log.error("[handleMissingPathVariableException] 요청 url에서 path variable이 누락된 경우");
+        log.error(e.getMessage());
+        log.error(String.valueOf(e.getHeaders()));
         HttpStatus httpStatus = PATH_VARIABLE_NOT_FOUND.getHttpStatus();
         return ResponseEntity.status(httpStatus)
                 .body(new BaseResponse(PATH_VARIABLE_NOT_FOUND));
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<BaseResponse> handlerNotFoundException(NoHandlerFoundException e){
+        log.error("[handlerNotFoundException] 구현되지 않은 API로 요청을 보낸 경우");
+        log.error(e.getMessage());
+        HttpStatus httpStatus = API_NOT_FOUND.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(API_NOT_FOUND));
     }
 }

--- a/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
+++ b/src/main/java/kuchat/server/common/exception/RequestControllerAdvice.java
@@ -8,21 +8,19 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
 
-import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_IMAGE;
-import static kuchat.server.common.response.BaseResponseStatus.OVER_SIZE_IMAGE;
+import static kuchat.server.common.response.BaseResponseStatus.*;
 
 @Slf4j
 @RestControllerAdvice
-public class ImageControllerAdvice {
+public class RequestControllerAdvice {
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    public ResponseEntity<BaseResponse> handleMissingImageException(MissingServletRequestParameterException e) {
-        // 클라이언트에서 multipartFile 필드 이름을 잘못 지정했거나, 파일 자체를 전송하지 않은 경우
-
-        log.error("[handleMissingImageException] 클라이언트 요청에서 multipartFile이 누락된 경우");
-        HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
+    public ResponseEntity<BaseResponse> handleMissingParameterException(MissingServletRequestParameterException e) {
+        log.error("[handleMissingParameterException] 클라이언트 요청에서 request parameter가 누락된 경우");
+        HttpStatus httpStatus = PARAMETER_NOT_FOUND.getHttpStatus();
         return ResponseEntity.status(httpStatus)
-                .body(new BaseResponse(NOT_FOUND_IMAGE));
+                .body(new BaseResponse(PARAMETER_NOT_FOUND));
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
@@ -31,5 +29,13 @@ public class ImageControllerAdvice {
         HttpStatus httpStatus = OVER_SIZE_IMAGE.getHttpStatus();
         return ResponseEntity.status(httpStatus)
                 .body(new BaseResponse(OVER_SIZE_IMAGE));
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<BaseResponse> handleMissingMultipartException(MultipartException e) {
+        log.error("[handleMissingMultipartException] 파일의 용량이 초과된 경우");
+        HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(NOT_FOUND_IMAGE));
     }
 }

--- a/src/main/java/kuchat/server/common/jwt/JwtTokenService.java
+++ b/src/main/java/kuchat/server/common/jwt/JwtTokenService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Date;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
-import static kuchat.server.domain.enums.Role.STUDENT;
 
 @Getter
 @Slf4j
@@ -73,23 +72,15 @@ public class JwtTokenService {
                 .compact();
     }
 
-    private void isExpired(String token) {
-        try {
-            log.info("[isExpired] token: " + token);
-            Jws<Claims> claims = Jwts.parser()
-                    .setSigningKey(secretKey)
-                    .parseClaimsJws(token);
-            if (claims.getBody().getExpiration().before(new Date())) {
-                log.info("토큰 만료 시간 = {}", claims.getBody().getExpiration());
-                log.info("현재 시간 = {}", new Date());
-                throw new KuchatException(EXPIRED_TOKEN);
-            }
-        } catch (ExpiredJwtException e) {
+    private void isExpired(String token) throws JwtException {
+        log.info("[isExpired] token: " + token);
+        Jws<Claims> claims = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token);
+        if (claims.getBody().getExpiration().before(new Date())) {
+            log.info("토큰 만료 시간 = {}", claims.getBody().getExpiration());
+            log.info("현재 시간 = {}", new Date());
             throw new KuchatException(EXPIRED_TOKEN);
-        } catch (MalformedJwtException e) {
-            throw new KuchatException(MALFORMED_TOKEN);
-        } catch (JwtException e) {
-            throw new KuchatException(INVALID_TOKEN);
         }
     }
 
@@ -99,7 +90,7 @@ public class JwtTokenService {
         // redis에 저장된 최신 리프레시 토큰과 일치 여부 확인 -> 토큰 무효화 및 재발급에 중요
         Long memberId = getMemberId(token);
         String stored = redisService.getRefreshToken(memberId);
-        if (token.equals(stored)){
+        if (token.equals(stored)) {
             return memberId;
         }
         throw new KuchatException(REFRESH_TOKEN_MISMATCH);
@@ -156,7 +147,7 @@ public class JwtTokenService {
         }
         String token = rawToken.replaceAll("Bearer ", "");
         isExpired(token);
-        if (!validateTokenType(token, type)){
+        if (!validateTokenType(token, type)) {
             throw new KuchatException(TOKEN_TYPE_MISMATCH);
         }
         return token;

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -16,6 +16,7 @@ public enum BaseResponseStatus {
     WEBSOCKET_CONNECTION_SUCCESS(1001, HttpStatus.OK, "웹소켓 연결 성공"),
 
     PARAMETER_NOT_FOUND(1010, HttpStatus.BAD_REQUEST, "요청 url의 쿼리 파라미터가 누락됐습니다."),
+    PATH_VARIABLE_NOT_FOUND(1011, HttpStatus.BAD_REQUEST, "요청 url의 path variable이 누락됐습니다."),
 
     // 2000 번대 : jwt 관련 상태 코드
     MALFORMED_TOKEN(2000, HttpStatus.UNAUTHORIZED, "토큰이 올바르게 구성되지 않았습니다."),
@@ -74,10 +75,11 @@ public enum BaseResponseStatus {
     BLOCKED_MEMBER_PROFILE(7000, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
     ALREADY_FRIEND(7001, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
     BLOCKED_MEMBER_APPLY(7002, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 사용자는 친구신청을 보낼 수 없습니다."),
+    NOT_FOUND_FRIEND(7003, HttpStatus.NOT_FOUND, "친구가 아닌 사용자들입니다."),
+    NOT_FOUND_APPLY(7004, HttpStatus.NOT_FOUND, "친구 신청이 존재하지 않습니다."),
 
 
     ALREADY_APPLY(70, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
-    NOT_FOUND_FRIEND(70, HttpStatus.NOT_FOUND, "친구가 아닌 사용자입니다."),
     NOT_FOUND_PLUSID(70, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
     NOT_FOUND_BLOCK(70, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
 

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -11,9 +11,11 @@ import org.springframework.http.HttpStatus;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public enum BaseResponseStatus {
-    // 1000 번대 : 요청 성공
+    // 1000 번대 : global 요청 성공/실패
     SUCCESS(1000, HttpStatus.OK, "요청에 성공하였습니다."),
     WEBSOCKET_CONNECTION_SUCCESS(1001, HttpStatus.OK, "웹소켓 연결 성공"),
+
+    PARAMETER_NOT_FOUND(1010, HttpStatus.BAD_REQUEST, "요청 url의 쿼리 파라미터가 누락됐습니다."),
 
     // 2000 번대 : jwt 관련 상태 코드
     MALFORMED_TOKEN(2000, HttpStatus.UNAUTHORIZED, "토큰이 올바르게 구성되지 않았습니다."),
@@ -24,9 +26,11 @@ public enum BaseResponseStatus {
     ACCESS_DENIED(2006, HttpStatus.UNAUTHORIZED, "요청을 처리할 권한이 없습니다."),
     REFRESH_TOKEN_MISMATCH(2007, HttpStatus.BAD_REQUEST, "리프레시 토큰이 일치하지 않습니다. 다시 로그인 해주세요."),
 
+
     //- 3000 번대 : oauth 관련 상태 코드
     NOT_FOUND_PLATFORM(3000, HttpStatus.NOT_FOUND, "존재하지 않는 플랫폼입니다."),
     OAUTH2_FAIL(3001, HttpStatus.INTERNAL_SERVER_ERROR, "소셜로그인이 제대로 처리되지 않았습니다. 다시 시도해주세요."),
+
 
     //- 4000 번대 : 회원가입/멤버 관련 상태 코드
     NOT_FOUND_LANGUAGE(4000, HttpStatus.NOT_FOUND, "존재하지 않는 언어입니다."),
@@ -42,7 +46,6 @@ public enum BaseResponseStatus {
     IMAGE_UPLOAD_FAIL(4010, HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다. 다시 시도해주세요."),
     NOT_FOUND_IMAGE(4011, HttpStatus.BAD_REQUEST, "요청에서 이미지 파일을 찾을 수 없습니다. 다시 시도해주세요."),
     OVER_SIZE_IMAGE(4012, HttpStatus.BAD_REQUEST, "이미지 파일이 용량을 초과하여 업로드할 수 없습니다. 업로드 가능한 크기는 최대 10MB 입니다."),
-
 
 
     //- 5000번대 : 채팅방(chatroom) 관련 코드

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -69,15 +69,17 @@ public enum BaseResponseStatus {
     MESSAGE_LENGTH_MISMATCH(6007, HttpStatus.BAD_REQUEST, "메세지의 payload 길이가 일치하지 않습니다."),
     NOT_FOUND_SESSION(6008, HttpStatus.NOT_FOUND, "사용자의 웹소켓 세션이 존재하지 않습니다. 다시 연결을 시도해주세요."),
 
-    //- 7000번대 : 친구 관련 코드
+    //- 7000번대 : 친구, 차단 관련 코드
 //    NOT_FOUND_FRIENDSHIP(7000, HttpStatus.NOT_FOUND, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
-    BLOCKED_MEMBER(7000, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
+    BLOCKED_MEMBER_PROFILE(7000, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
+    ALREADY_FRIEND(7001, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
+    BLOCKED_MEMBER_APPLY(7002, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 사용자는 친구신청을 보낼 수 없습니다."),
+
 
     ALREADY_APPLY(70, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
     NOT_FOUND_FRIEND(70, HttpStatus.NOT_FOUND, "친구가 아닌 사용자입니다."),
     NOT_FOUND_PLUSID(70, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
     NOT_FOUND_BLOCK(70, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
-    ALREADY_FRIEND(70, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
 
     //- 8000번대 : 알림 관련 코드
 

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -76,7 +76,7 @@ public enum BaseResponseStatus {
     BLOCKED_MEMBER_PROFILE(7000, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 상대의 프로필을 조회할 수 없습니다."),
     ALREADY_FRIEND(7001, HttpStatus.BAD_REQUEST, "이미 친구 관계인 사이에서 친구 관계를 중복하여 맺을 수 없습니다"),
     BLOCKED_MEMBER_APPLY(7002, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 사용자는 친구신청을 보낼 수 없습니다."),
-    NOT_FOUND_FRIEND(7003, HttpStatus.NOT_FOUND, "친구가 아닌 사용자들입니다."),
+    NOT_FOUND_FRIEND(7003, HttpStatus.NOT_FOUND, "해당 사용자와의 친구 관계가 존재하지 않습니다."),
     NOT_FOUND_APPLY(7004, HttpStatus.NOT_FOUND, "친구 신청이 존재하지 않습니다."),
     ALREADY_BLOCK(7005, HttpStatus.BAD_REQUEST, "이미 차단했거나 차단당한 사용자끼리는 차단을 할 수 없습니다."),
     NOT_FOUND_PLUSID(7006, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),

--- a/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
+++ b/src/main/java/kuchat/server/common/response/BaseResponseStatus.java
@@ -17,6 +17,7 @@ public enum BaseResponseStatus {
 
     PARAMETER_NOT_FOUND(1010, HttpStatus.BAD_REQUEST, "요청 url의 쿼리 파라미터가 누락됐습니다."),
     PATH_VARIABLE_NOT_FOUND(1011, HttpStatus.BAD_REQUEST, "요청 url의 path variable이 누락됐습니다."),
+    API_NOT_FOUND(1012, HttpStatus.NOT_FOUND, "잘못된 요청입니다. 요청 URL을 확인해주세요."),
 
     // 2000 번대 : jwt 관련 상태 코드
     MALFORMED_TOKEN(2000, HttpStatus.UNAUTHORIZED, "토큰이 올바르게 구성되지 않았습니다."),
@@ -77,11 +78,12 @@ public enum BaseResponseStatus {
     BLOCKED_MEMBER_APPLY(7002, HttpStatus.BAD_REQUEST, "차단하거나 차단 당한 사용자는 친구신청을 보낼 수 없습니다."),
     NOT_FOUND_FRIEND(7003, HttpStatus.NOT_FOUND, "친구가 아닌 사용자들입니다."),
     NOT_FOUND_APPLY(7004, HttpStatus.NOT_FOUND, "친구 신청이 존재하지 않습니다."),
+    ALREADY_BLOCK(7005, HttpStatus.BAD_REQUEST, "이미 차단했거나 차단당한 사용자끼리는 차단을 할 수 없습니다."),
+    NOT_FOUND_PLUSID(7006, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
+    NOT_FOUND_BLOCK(7007, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
 
 
-    ALREADY_APPLY(70, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
-    NOT_FOUND_PLUSID(70, HttpStatus.NOT_FOUND, "해당 plus id를 사용하는 사용자가 존재하지 않습니다."),
-    NOT_FOUND_BLOCK(70, HttpStatus.NOT_FOUND, "해당 사용자들 사이에 차단 관계가 존재하지 않습니다."),
+//    ALREADY_APPLY(70, HttpStatus.BAD_REQUEST, "둘 사이에 보낸 요청이 존재합니다."),
 
     //- 8000번대 : 알림 관련 코드
 

--- a/src/main/java/kuchat/server/domain/block/controller/BlockController.java
+++ b/src/main/java/kuchat/server/domain/block/controller/BlockController.java
@@ -2,9 +2,11 @@ package kuchat.server.domain.block.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.block.dto.BlockMemberResponses;
 import kuchat.server.domain.block.service.BlockService;
+import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,14 +23,15 @@ import static kuchat.server.common.response.BaseResponseStatus.SUCCESS;
 public class BlockController {
 
     private final BlockService blockService;
+    private final FriendService friendService;
 
     @Operation(summary = "사용자 차단하기")        // 친구가 아니었어도 차단 가능
     @PostMapping("/{id}")
-    public ResponseEntity<BaseResponseStatus> block(@Auth Member member,
-                                  @PathVariable("id") Long blockMemberId) {
+    public ResponseEntity<BaseResponse> block(@Auth Member member,
+                                              @PathVariable("id") Long blockMemberId) {
         log.info("[blockMember] id = {} 인 사용자가 id = {} 인 사용자를 차단함. ", member.getId(), blockMemberId);
-        blockService.block(member, blockMemberId);
-        return ResponseEntity.ok(SUCCESS);
+        friendService.deleteFriendByMembers(member.getId(), blockMemberId);
+        return blockService.block(member, blockMemberId);
     }
 
     @Operation(summary = "사용자 차단 해제하기")

--- a/src/main/java/kuchat/server/domain/block/controller/BlockController.java
+++ b/src/main/java/kuchat/server/domain/block/controller/BlockController.java
@@ -9,6 +9,9 @@ import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,10 +43,13 @@ public class BlockController {
     }
 
     @Operation(summary = "내가 차단한 사용자 목록 조회")
-    @GetMapping("")
-    public ResponseEntity<BlockMemberResponses> blockMemberList(@Auth Member member) {
+    @GetMapping
+    public ResponseEntity<BlockMemberResponses> blockMemberList(@Auth Member member,
+                                                                @PageableDefault(size = 20,
+                                                                        sort = "createdDate",
+                                                                        direction = Sort.Direction.DESC)
+                                                                Pageable pageable) {
         log.info("[blockMemberList] {} 가 차단한 사용자들 목록 조회", member.getId());
-        BlockMemberResponses response = blockService.getblocks(member);
-        return ResponseEntity.ok(response);
+        return blockService.getblocks(member, pageable);
     }
 }

--- a/src/main/java/kuchat/server/domain/block/controller/BlockController.java
+++ b/src/main/java/kuchat/server/domain/block/controller/BlockController.java
@@ -3,7 +3,6 @@ package kuchat.server.domain.block.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
 import kuchat.server.common.response.BaseResponse;
-import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.block.dto.BlockMemberResponses;
 import kuchat.server.domain.block.service.BlockService;
 import kuchat.server.domain.friend.service.FriendService;
@@ -12,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static kuchat.server.common.response.BaseResponseStatus.SUCCESS;
 
 
 @Slf4j
@@ -26,21 +23,20 @@ public class BlockController {
     private final FriendService friendService;
 
     @Operation(summary = "사용자 차단하기")        // 친구가 아니었어도 차단 가능
-    @PostMapping("/{id}")
+    @PostMapping("/{memberId}")
     public ResponseEntity<BaseResponse> block(@Auth Member member,
-                                              @PathVariable("id") Long blockMemberId) {
+                                              @PathVariable("memberId") Long blockMemberId) {
         log.info("[blockMember] id = {} 인 사용자가 id = {} 인 사용자를 차단함. ", member.getId(), blockMemberId);
-        friendService.deleteFriendByMembers(member.getId(), blockMemberId);
+        friendService.deleteIfFriend(member.getId(), blockMemberId);
         return blockService.block(member, blockMemberId);
     }
 
     @Operation(summary = "사용자 차단 해제하기")
-    @DeleteMapping("/{id}/release")
-    public ResponseEntity<BaseResponseStatus> release(@Auth Member member,
-                                                      @PathVariable("id") Long releaseMemberId) {
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<BaseResponse> release(@Auth Member member,
+                                                @PathVariable("memberId") Long releaseMemberId) {
         log.info("[release] id = {} 인 사용자가 id = {} 인 사용자를 차단 해제함. ", member.getId(), releaseMemberId);
-        blockService.release(member, releaseMemberId);
-        return ResponseEntity.ok(SUCCESS);
+        return blockService.release(member, releaseMemberId);
     }
 
     @Operation(summary = "내가 차단한 사용자 목록 조회")

--- a/src/main/java/kuchat/server/domain/block/dto/BlockMemberResponse.java
+++ b/src/main/java/kuchat/server/domain/block/dto/BlockMemberResponse.java
@@ -1,5 +1,6 @@
 package kuchat.server.domain.block.dto;
 
+import kuchat.server.domain.block.Block;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.ProfileResponse;
 import lombok.AllArgsConstructor;
@@ -12,13 +13,12 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 public class BlockMemberResponse {
-    private Long friendId;
+    private Long memberId;
     private ProfileResponse profile;
-    private String name;
-    private String profileImage;
 
-    public BlockMemberResponse(Member member) {
-        friendId = member.getId();
+    public BlockMemberResponse(Block block) {
+        Member member = block.getBlocked();
+        memberId = member.getId();
         this.profile = new ProfileResponse(member.getProfile());
     }
 }

--- a/src/main/java/kuchat/server/domain/block/dto/BlockMemberResponses.java
+++ b/src/main/java/kuchat/server/domain/block/dto/BlockMemberResponses.java
@@ -1,10 +1,13 @@
 package kuchat.server.domain.block.dto;
 
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
+import kuchat.server.domain.block.Block;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -12,12 +15,13 @@ import java.util.List;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class BlockMemberResponses {
-    List<BlockMemberResponse> blockMemberResponses;
-    BaseResponseStatus baseResponseStatus;
+public class BlockMemberResponses extends BaseResponse {
+    List<BlockMemberResponse> responses;
 
-    public BlockMemberResponses(List<BlockMemberResponse> blockMemberResponses) {
-        this.blockMemberResponses = blockMemberResponses;
-        baseResponseStatus = BaseResponseStatus.SUCCESS;
+    public BlockMemberResponses(BaseResponseStatus responseStatus, Page<Block> blocks) {
+        super(responseStatus);
+        this.responses = blocks.stream()
+                .map(BlockMemberResponse::new)
+                .toList();
     }
 }

--- a/src/main/java/kuchat/server/domain/block/repository/BlockRepository.java
+++ b/src/main/java/kuchat/server/domain/block/repository/BlockRepository.java
@@ -2,18 +2,22 @@ package kuchat.server.domain.block.repository;
 
 import kuchat.server.domain.block.Block;
 import kuchat.server.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
 
     Optional<Block> findByBlockerAndBlocked(Member blocker, Member blocked);
 
-    List<Block> findByBlocker(Member member);
+    @Query("select b from Block b " +
+            "join fetch b.blocked bb " +
+            "where b.blocker = :member")
+    Page<Block> findByBlocker(Member member, Pageable pageable);
 
     @Query("select b from Block b " +
             "where (b.blocked.id = :id1 and b.blocker.id = :id2) or (b.blocked.id = :id2 and b.blocker.id = :id1)")

--- a/src/main/java/kuchat/server/domain/block/service/BlockService.java
+++ b/src/main/java/kuchat/server/domain/block/service/BlockService.java
@@ -3,18 +3,18 @@ package kuchat.server.domain.block.service;
 import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.block.Block;
-import kuchat.server.domain.block.dto.BlockMemberResponse;
 import kuchat.server.domain.block.dto.BlockMemberResponses;
 import kuchat.server.domain.block.repository.BlockRepository;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
@@ -60,14 +60,11 @@ public class BlockService {
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
-    public BlockMemberResponses getblocks(Member member) {
+    public ResponseEntity<BlockMemberResponses> getblocks(Member member, Pageable pageable) {
         log.info("[block] {} 번 사용자가 차단한 사용자 목록 조회", member.getId());
-        List<BlockMemberResponse> responses = blockRepository.findByBlocker(member)
-                .stream()
-                .map(Block::getBlocked)
-                .map(BlockMemberResponse::new)
-                .toList();
-        return new BlockMemberResponses(responses);
+        Page<Block> blocks = blockRepository.findByBlocker(member, pageable);
+        BlockMemberResponses response = new BlockMemberResponses(SUCCESS, blocks);
+        return ResponseEntity.ok(response);
     }
 
     private Member getMember(Long memberId) {

--- a/src/main/java/kuchat/server/domain/block/service/BlockService.java
+++ b/src/main/java/kuchat/server/domain/block/service/BlockService.java
@@ -1,23 +1,25 @@
 package kuchat.server.domain.block.service;
 
 import kuchat.server.common.exception.KuchatException;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.block.Block;
 import kuchat.server.domain.block.dto.BlockMemberResponse;
 import kuchat.server.domain.block.dto.BlockMemberResponses;
 import kuchat.server.domain.block.repository.BlockRepository;
 import kuchat.server.domain.friend.repository.FriendRepository;
+import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
-import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_BLOCK;
-import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_MEMBER;
+import static kuchat.server.common.response.BaseResponseStatus.*;
 
 
 @Slf4j
@@ -27,24 +29,14 @@ import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_MEMBER;
 public class BlockService {
 
     private final BlockRepository blockRepository;
-    private final FriendRepository friendRepository;
     private final MemberRepository memberRepository;
 
-    public void block(Member member, Long blockMemberId) {
+    public ResponseEntity<BaseResponse> block(Member member, Long blockMemberId) {
         log.info("[block] {} 번 사용자가 {} 번 사용자를 차단함.", member.getId(), blockMemberId);
         Member blocked = getMember(blockMemberId);
-
-        deleteFriend(member, blocked);          // member 가 blocked 를 팔로우한 경우, 제거
-        deleteFriend(blocked, member);          // blocked 가 member 를 팔로우한 경우, 제거
-
         Block block = new Block(member, blocked);
         blockRepository.save(block);
-    }
-
-    // m1 이 m2를 팔로우한 경우, 그 때 생성된 friend 를 제거함
-    private void deleteFriend(Member m1, Member m2) {
-        friendRepository.findByMembers(m1, m2)
-                .ifPresent(friendRepository::delete);
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
     public void release(Member member, Long releaseMemberId) {

--- a/src/main/java/kuchat/server/domain/block/service/BlockService.java
+++ b/src/main/java/kuchat/server/domain/block/service/BlockService.java
@@ -6,8 +6,6 @@ import kuchat.server.domain.block.Block;
 import kuchat.server.domain.block.dto.BlockMemberResponse;
 import kuchat.server.domain.block.dto.BlockMemberResponses;
 import kuchat.server.domain.block.repository.BlockRepository;
-import kuchat.server.domain.friend.repository.FriendRepository;
-import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,20 +29,35 @@ public class BlockService {
     private final BlockRepository blockRepository;
     private final MemberRepository memberRepository;
 
+    @Transactional
     public ResponseEntity<BaseResponse> block(Member member, Long blockMemberId) {
         log.info("[block] {} 번 사용자가 {} 번 사용자를 차단함.", member.getId(), blockMemberId);
+        validateAlreadyBlock(member, blockMemberId);
         Member blocked = getMember(blockMemberId);
         Block block = new Block(member, blocked);
         blockRepository.save(block);
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
-    public void release(Member member, Long releaseMemberId) {
+    private void validateAlreadyBlock(Member member, Long blockMemberId) {
+        // 이미 차단한 관계인지 확인하기
+        if (blockRepository.findByIds(member.getId(), blockMemberId).isPresent()) {
+            throw new KuchatException(ALREADY_BLOCK);
+        }
+    }
+
+    @Transactional
+    public ResponseEntity<BaseResponse> release(Member member, Long releaseMemberId) {
         log.info("[release] {} 번 사용자가 차단한 {} 번 사용자를 차단 해제함.", member.getId(), releaseMemberId);
         Member released = getMember(releaseMemberId);
-        Block block = blockRepository.findByBlockerAndBlocked(member, released)
-                .orElseThrow(() -> new KuchatException(NOT_FOUND_BLOCK));
-        blockRepository.delete(block);
+        blockRepository.findByBlockerAndBlocked(member, released)
+                .ifPresentOrElse(
+                        blockRepository::delete,
+                        () -> {
+                            throw new KuchatException(NOT_FOUND_BLOCK);
+                        }
+                );
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
     public BlockMemberResponses getblocks(Member member) {
@@ -62,7 +75,7 @@ public class BlockService {
                 .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
     }
 
-    public boolean isBlockOrBlocked(Long member1Id, Long member2Id){
+    public boolean isBlockOrBlocked(Long member1Id, Long member2Id) {
         Optional<Block> optionalBlock = blockRepository.findByIds(member1Id, member2Id);
         return optionalBlock.isPresent();
     }

--- a/src/main/java/kuchat/server/domain/friend/Friend.java
+++ b/src/main/java/kuchat/server/domain/friend/Friend.java
@@ -36,4 +36,8 @@ public class Friend extends BaseTime {
         this.receiver = receiver;
     }
 
+    public void accept(){
+        this.acceptance = true;
+    }
+
 }

--- a/src/main/java/kuchat/server/domain/friend/Friend.java
+++ b/src/main/java/kuchat/server/domain/friend/Friend.java
@@ -1,7 +1,6 @@
 package kuchat.server.domain.friend;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import kuchat.server.domain.BaseTime;
 import kuchat.server.domain.member.Member;
 import lombok.Builder;
@@ -36,8 +35,20 @@ public class Friend extends BaseTime {
         this.receiver = receiver;
     }
 
-    public void accept(){
+    public void accept() {
         this.acceptance = true;
+    }
+
+    public void unfollow(Member unfollower, Member follower) {
+        this.acceptance = false;        // 친구신청 수락 비활성화
+        if (unfollower.equals(sender)) {
+            toggleFollowDirection(unfollower, follower);
+        }
+    }
+
+    private void toggleFollowDirection(Member unfollower, Member follower) {
+        this.sender = follower;
+        this.receiver = unfollower;
     }
 
 }

--- a/src/main/java/kuchat/server/domain/friend/Friend.java
+++ b/src/main/java/kuchat/server/domain/friend/Friend.java
@@ -30,7 +30,6 @@ public class Friend extends BaseTime {
     @Column(nullable = false)
     private boolean acceptance = false;
 
-
     @Builder
     public Friend(Member sender, Member receiver) {
         this.sender = sender;

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -38,7 +38,7 @@ public class FriendController {
         return friendService.acceptApply(member.getId(), friendId);
     }
 
-    @Operation(summary = "친구신청 목록 조회")
+    @Operation(summary = "내가 받은 친구신청 목록 조회")
     @GetMapping("/apply")
     public ResponseEntity<FriendApplyResponses> getFriendApplyList(@Auth Member member,
                                                                    @PageableDefault(size = 20,
@@ -49,6 +49,22 @@ public class FriendController {
         return friendService.getFriendApplyList(member, pageable);
     }
 
+    @Operation(summary = "친구신청 삭제")
+    @DeleteMapping("/apply/{memberId}")
+    public ResponseEntity<BaseResponse> deleteFriendApply(@Auth Member member,
+                                                     @PathVariable("memberId") Long friendMemberId) {
+        log.info("[deleteFriend] member id = {} 인 사용자가 보낸 친구신청 삭제", friendMemberId);
+        return friendService.delete(member, friendMemberId, false);
+    }
+
+    @Operation(summary = "친구 삭제")
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<BaseResponse> deleteFriend(@Auth Member member,
+                                                     @PathVariable("memberId") Long friendMemberId) {
+        log.info("[deleteFriend] member id = {} 인 사용자와의 친구 관계 삭제", friendMemberId);
+        return friendService.breakFriendship(member, friendMemberId);
+    }
+
     @Operation(summary = "친구 목록 조회 (이름 검색)")
     @GetMapping
     public ResponseEntity<BaseResponse> getFriendList(@Auth Member member,
@@ -56,13 +72,6 @@ public class FriendController {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);
         return friendService.getFriendList(member, friendName);
     }
-
-    @Operation(summary = "친구 삭제")
-    @DeleteMapping("/{id}")
-    public ResponseEntity<BaseResponse> deleteFriend(@Auth Member member,
-                                                     @PathVariable("id") Long friendMemberId) {
-        log.info("[deleteFriend] member id = {} 인 사용자와의 친구 관계 삭제", friendMemberId);
-        return friendService.delete(member, friendMemberId);
-    }
-
+// 친구 신청 받은거 목록 조회
+// 친구 신청 준거 목록 조회
 }

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -31,22 +31,28 @@ public class FriendController {
         return friendService.applyByPlusId(member, plusId);
     }
 
+    @Operation(summary = "친구신청 수락하기")
+    @PostMapping("/accept/{friendId}")
+    public ResponseEntity<BaseResponse> acceptFriendApply(@Auth Member member,
+                                                    @PathVariable("friendId") Long friendId) {
+        log.info("[acceptFriendApply] friendId = {} 인 친구신청을 {} 가 수락함", friendId, member.getId());
+        return friendService.acceptApply(member.getId(), friendId);
+    }
+
     @Operation(summary = "친구 목록 조회 (이름 검색)")
     @GetMapping("")
-    public ResponseEntity<FriendResponses> getFriendList(@Auth Member member,
+    public ResponseEntity<BaseResponse> getFriendList(@Auth Member member,
                                                          @RequestParam("name") String friendName) {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);
-        FriendResponses response = friendService.getFriendList(member, friendName);
-        return ResponseEntity.ok(response);
+        return friendService.getFriendList(member, friendName);
     }
 
     @Operation(summary = "친구 삭제")
     @DeleteMapping("/{id}")
-    public ResponseEntity<BaseResponseStatus> deleteFriend(@Auth Member member,
+    public ResponseEntity<BaseResponse> deleteFriend(@Auth Member member,
                                                            @PathVariable("id") Long friendId) {
         log.info("[deleteFriend] member id = {} 인 사용자와의 친구 관계 삭제", friendId);
-        friendService.delete(member, friendId);
-        return ResponseEntity.ok(SUCCESS);
+        return friendService.delete(member, friendId);
     }
 
 }

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -2,6 +2,7 @@ package kuchat.server.domain.friend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.friend.dto.FriendResponse;
 import kuchat.server.domain.friend.dto.FriendResponses;
@@ -22,22 +23,12 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    @Operation(summary = "친구 프로필에서 친구 신청 보내기")
-    @PostMapping("/{id}")
-    public ResponseEntity<BaseResponseStatus> addFriend(@Auth Member member,
-                                                        @PathVariable("id") Long friendId) {
-        log.info("[applyFriend] id = {} 인 사용자를 친구로 추가", friendId);
-        friendService.addFriend(member, friendId);
-        return ResponseEntity.ok(SUCCESS);
-    }
-
     @Operation(summary = "plus id로 친구 신청 보내기")
-    @PostMapping("plusId/{plusId}")
-    public ResponseEntity<BaseResponseStatus> sendApplyByPlusId(@Auth Member member,
-                                                                @PathVariable("plusId") String plusId) {
+    @PostMapping("/apply/{plusId}")
+    public ResponseEntity<BaseResponse> sendApplyByPlusId(@Auth Member member,
+                                                          @PathVariable("plusId") String plusId) {
         log.info("[applyFriendByPlusId] plusId = {} 인 친구에서 {} 가 친구 요청을 보냄", plusId, member.getId());
-        friendService.addByPlusId(member, plusId);
-        return ResponseEntity.ok(SUCCESS);
+        return friendService.applyByPlusId(member, plusId);
     }
 
     @Operation(summary = "친구 목록 조회 (이름 검색)")
@@ -46,15 +37,6 @@ public class FriendController {
                                                          @RequestParam("name") String friendName) {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);
         FriendResponses response = friendService.getFriendList(member, friendName);
-        return ResponseEntity.ok(response);
-    }
-
-    @Operation(summary = "다른 사용자 프로필 조회 (차단했거나 차단당한 사용자의 프로필은 조회 불가능)")
-    @GetMapping("/{id}/profile")
-    public ResponseEntity<FriendResponse> getFriendProfile(@Auth Member member,
-                                                           @PathVariable("id") Long friendId) {
-        log.info("[getFriendProfile] id = {} 인 사용자의 프로필 조회 요청", friendId);
-        FriendResponse response = friendService.getFriendProfile(member.getId(), friendId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -3,17 +3,12 @@ package kuchat.server.domain.friend.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
 import kuchat.server.common.response.BaseResponse;
-import kuchat.server.common.response.BaseResponseStatus;
-import kuchat.server.domain.friend.dto.FriendResponse;
-import kuchat.server.domain.friend.dto.FriendResponses;
 import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import static kuchat.server.common.response.BaseResponseStatus.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,9 +27,9 @@ public class FriendController {
     }
 
     @Operation(summary = "친구신청 수락하기")
-    @PostMapping("/accept/{friendId}")
+    @PutMapping("/accept/{friendId}")
     public ResponseEntity<BaseResponse> acceptFriendApply(@Auth Member member,
-                                                    @PathVariable("friendId") Long friendId) {
+                                                          @PathVariable("friendId") Long friendId) {
         log.info("[acceptFriendApply] friendId = {} 인 친구신청을 {} 가 수락함", friendId, member.getId());
         return friendService.acceptApply(member.getId(), friendId);
     }
@@ -42,7 +37,7 @@ public class FriendController {
     @Operation(summary = "친구 목록 조회 (이름 검색)")
     @GetMapping("")
     public ResponseEntity<BaseResponse> getFriendList(@Auth Member member,
-                                                         @RequestParam("name") String friendName) {
+                                                      @RequestParam("name") String friendName) {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);
         return friendService.getFriendList(member, friendName);
     }
@@ -50,9 +45,9 @@ public class FriendController {
     @Operation(summary = "친구 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse> deleteFriend(@Auth Member member,
-                                                           @PathVariable("id") Long friendId) {
-        log.info("[deleteFriend] member id = {} 인 사용자와의 친구 관계 삭제", friendId);
-        return friendService.delete(member, friendId);
+                                                     @PathVariable("id") Long friendMemberId) {
+        log.info("[deleteFriend] member id = {} 인 사용자와의 친구 관계 삭제", friendMemberId);
+        return friendService.delete(member, friendMemberId);
     }
 
 }

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -3,10 +3,14 @@ package kuchat.server.domain.friend.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
 import kuchat.server.common.response.BaseResponse;
+import kuchat.server.domain.friend.dto.FriendApplyResponses;
 import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,8 +38,19 @@ public class FriendController {
         return friendService.acceptApply(member.getId(), friendId);
     }
 
+    @Operation(summary = "친구신청 목록 조회")
+    @GetMapping("/apply")
+    public ResponseEntity<FriendApplyResponses> getFriendApplyList(@Auth Member member,
+                                                                   @PageableDefault(size = 20,
+                                                                           sort = "createdDate",
+                                                                           direction = Sort.Direction.DESC)
+                                                                   Pageable pageable) {
+        log.info("[getFriendApplyList] id={} , name={} 가 받은 친구 신청 목록 조회", member.getId(), member.getName());
+        return friendService.getFriendApplyList(member, pageable);
+    }
+
     @Operation(summary = "친구 목록 조회 (이름 검색)")
-    @GetMapping("")
+    @GetMapping
     public ResponseEntity<BaseResponse> getFriendList(@Auth Member member,
                                                       @RequestParam("name") String friendName) {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);

--- a/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
+++ b/src/main/java/kuchat/server/domain/friend/controller/FriendController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import kuchat.server.common.jwt.argumentResolver.Auth;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.friend.dto.FriendApplyResponses;
+import kuchat.server.domain.friend.dto.FriendResponses;
 import kuchat.server.domain.friend.service.FriendService;
 import kuchat.server.domain.member.Member;
 import lombok.RequiredArgsConstructor;
@@ -67,11 +68,10 @@ public class FriendController {
 
     @Operation(summary = "친구 목록 조회 (이름 검색)")
     @GetMapping
-    public ResponseEntity<BaseResponse> getFriendList(@Auth Member member,
-                                                      @RequestParam("name") String friendName) {
+    public ResponseEntity<FriendResponses> getFriendList(@Auth Member member,
+                                                         @RequestParam(value = "name", required = false) String friendName,
+                                                         @PageableDefault(size = 20, sort = "receiver.profile.name") Pageable pageable) {
         log.info("[getFriendList] 친구 목록 검색 및 조회. 검색 문자열 = '{}'", friendName);
-        return friendService.getFriendList(member, friendName);
+        return friendService.getFriendList(member, friendName, pageable);
     }
-// 친구 신청 받은거 목록 조회
-// 친구 신청 준거 목록 조회
 }

--- a/src/main/java/kuchat/server/domain/friend/dto/ApplySenderProfile.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/ApplySenderProfile.java
@@ -1,0 +1,31 @@
+package kuchat.server.domain.friend.dto;
+
+import kuchat.server.common.response.BaseResponseStatus;
+import kuchat.server.domain.member.Member;
+import kuchat.server.domain.member.dto.LanguageResponse;
+import kuchat.server.domain.member.dto.ProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Getter
+@ToString
+@Slf4j
+@NoArgsConstructor
+public class ApplySenderProfile {
+    private Long memberId;
+    private String plusId;
+    private LanguageResponse language;
+    private ProfileResponse profile;
+
+
+    public ApplySenderProfile (Member member) {
+        memberId = member.getId();
+        plusId = member.getPlusId();
+        profile = new ProfileResponse(member.getProfile());
+        language = new LanguageResponse(member.getLanguage());
+    }
+}

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponse.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponse.java
@@ -1,32 +1,30 @@
 package kuchat.server.domain.friend.dto;
 
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import kuchat.server.domain.friend.Friend;
-import kuchat.server.domain.member.dto.DetailProfileResponse;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @ToString
 @Slf4j
-@AllArgsConstructor
 @NoArgsConstructor
 public class FriendApplyResponse {
-    private Long friendApplyId;
-
+    private Long friendId;
+    private FriendProfile friendProfile;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime applySentTime;
 
-    private ApplySenderProfile applySenderProfile;
-
-    public FriendApplyResponse(Friend friend){
-        this.friendApplyId = friend.getId();
-        this.applySenderProfile = new ApplySenderProfile(friend.getSender());
+    FriendApplyResponse(Friend friend) {
+        this.friendId = friend.getId();
+        this.friendProfile = new FriendProfile(friend.getSender());
         this.applySentTime = friend.getCreatedDate();
     }
 }

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponse.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponse.java
@@ -1,0 +1,32 @@
+package kuchat.server.domain.friend.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import kuchat.server.domain.friend.Friend;
+import kuchat.server.domain.member.dto.DetailProfileResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@Slf4j
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendApplyResponse {
+    private Long friendApplyId;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime applySentTime;
+
+    private ApplySenderProfile applySenderProfile;
+
+    public FriendApplyResponse(Friend friend){
+        this.friendApplyId = friend.getId();
+        this.applySenderProfile = new ApplySenderProfile(friend.getSender());
+        this.applySentTime = friend.getCreatedDate();
+    }
+}

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponses.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponses.java
@@ -1,0 +1,29 @@
+package kuchat.server.domain.friend.dto;
+
+import kuchat.server.common.response.BaseResponse;
+import kuchat.server.common.response.BaseResponseStatus;
+import kuchat.server.domain.friend.Friend;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@ToString
+@Slf4j
+@NoArgsConstructor
+public class FriendApplyResponses extends BaseResponse {
+    List<FriendApplyResponse> applyResponses;
+
+    public FriendApplyResponses(BaseResponseStatus responseStatus, Page<Friend> friends){
+        super(responseStatus);
+        this.applyResponses = friends.stream()
+                .map(FriendApplyResponse::new)
+                .toList();
+    }
+
+}

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponses.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendApplyResponses.java
@@ -3,9 +3,9 @@ package kuchat.server.domain.friend.dto;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.friend.Friend;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,13 +13,14 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 @Getter
+@Setter
 @ToString
 @Slf4j
 @NoArgsConstructor
 public class FriendApplyResponses extends BaseResponse {
-    List<FriendApplyResponse> applyResponses;
+    private List<FriendApplyResponse> applyResponses;
 
-    public FriendApplyResponses(BaseResponseStatus responseStatus, Page<Friend> friends){
+    public FriendApplyResponses(BaseResponseStatus responseStatus, Page<Friend> friends) {
         super(responseStatus);
         this.applyResponses = friends.stream()
                 .map(FriendApplyResponse::new)

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendProfile.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendProfile.java
@@ -1,10 +1,8 @@
 package kuchat.server.domain.friend.dto;
 
-import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.LanguageResponse;
 import kuchat.server.domain.member.dto.ProfileResponse;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -15,14 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 @ToString
 @Slf4j
 @NoArgsConstructor
-public class ApplySenderProfile {
+public class FriendProfile {
     private Long memberId;
     private String plusId;
     private LanguageResponse language;
     private ProfileResponse profile;
 
 
-    public ApplySenderProfile (Member member) {
+    public FriendProfile(Member member) {
         memberId = member.getId();
         plusId = member.getPlusId();
         profile = new ProfileResponse(member.getProfile());

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendResponse.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendResponse.java
@@ -1,31 +1,27 @@
 package kuchat.server.domain.friend.dto;
 
 import kuchat.server.domain.member.Member;
-import kuchat.server.domain.member.dto.ProfileResponse;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
-
-import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
 
 @Getter
+@Setter
 @ToString
-@AllArgsConstructor
+@Slf4j
 @NoArgsConstructor
 public class FriendResponse {
-    private Long friendId;
-    private ProfileResponse profile;
-    private LocalDateTime sentTime;
+    private Long memberId;
+    private String name;
+    private String profileImage;
+    private String aboutMe;
 
-    public FriendResponse(Member member, LocalDateTime sentTime) {
-        friendId = member.getId();
-        this.profile = new ProfileResponse(member.getProfile());
-        this.sentTime = sentTime;
-    }
-
-    public FriendResponse(Member member) {
-        friendId = member.getId();
-        this.profile = new ProfileResponse(member.getProfile());
+    FriendResponse(Member member) {
+        this.memberId = member.getId();
+        this.name = member.getName();
+        this.profileImage = member.getProfile().getProfileImage();
+        this.aboutMe = member.getProfile().getAboutMe();
     }
 }

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendResponses.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendResponses.java
@@ -2,25 +2,27 @@ package kuchat.server.domain.friend.dto;
 
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
-import lombok.AllArgsConstructor;
+import kuchat.server.domain.friend.Friend;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-
 @Getter
 @ToString
-@AllArgsConstructor
+@Slf4j
 @NoArgsConstructor
 public class FriendResponses extends BaseResponse {
     private List<FriendResponse> responses;
-    private BaseResponseStatus baseResponseStatus;
 
-    public FriendResponses(BaseResponseStatus responseStatus, List<FriendResponse> responses) {
+    public FriendResponses(BaseResponseStatus responseStatus, Page<Friend> friends) {
         super(responseStatus);
-        this.responses = responses;
-        baseResponseStatus = BaseResponseStatus.SUCCESS;
+        this.responses = friends.stream()
+                .map(friend -> new FriendResponse(friend.getReceiver()))
+                .toList();
     }
+
 }

--- a/src/main/java/kuchat/server/domain/friend/dto/FriendResponses.java
+++ b/src/main/java/kuchat/server/domain/friend/dto/FriendResponses.java
@@ -1,5 +1,6 @@
 package kuchat.server.domain.friend.dto;
 
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,11 +14,12 @@ import java.util.List;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
-public class FriendResponses {
+public class FriendResponses extends BaseResponse {
     private List<FriendResponse> responses;
     private BaseResponseStatus baseResponseStatus;
 
-    public FriendResponses(List<FriendResponse> responses) {
+    public FriendResponses(BaseResponseStatus responseStatus, List<FriendResponse> responses) {
+        super(responseStatus);
         this.responses = responses;
         baseResponseStatus = BaseResponseStatus.SUCCESS;
     }

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -16,11 +16,13 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findAllByName(@Param("member") Member member, @Param("name") String name);       // member 의 친구들 검색
 
     @Query("select f from Friend f " +
-            "where (f.sender = :sender and f.receiver = :receiver) " +
-            "or (f.sender = :receiver and f.receiver = :sender)")
-    Optional<Friend> findByMembers(@Param("sender") Member follower, @Param("receiver") Member receiver);
+            "where (f.sender.id = :senderId and f.receiver.id = :receiverId) " +
+            "or (f.sender.id = :receiverId and f.receiver.id = :senderId)")
+    Optional<Friend> findByMembers(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
 
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
+
+    Optional<Friend> findByIdAndReceiver_IdAndAcceptance(Long friendId, Long memberId, boolean acceptance);
 
 //    @Query("select f from Friend f " +
 //            "where (f.sender = :sender and f.receiver = :receiver) " +

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -16,6 +16,14 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findAllByName(@Param("member") Member member, @Param("name") String name);       // member 의 친구들 검색
 
     @Query("select f from Friend f " +
-            "where (f.sender = :sender and f.receiver = :receiver)")
+            "where (f.sender = :sender and f.receiver = :receiver) " +
+            "or (f.sender = :receiver and f.receiver = :sender)")
     Optional<Friend> findByMembers(@Param("sender") Member follower, @Param("receiver") Member receiver);
+
+    Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
+
+//    @Query("select f from Friend f " +
+//            "where (f.sender = :sender and f.receiver = :receiver) " +
+//            "or (f.sender = :receiver and f.receiver = :sender)")
+//    Optional<Friend> findFirstByMembers(Member member, Member friendMember);
 }

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -8,14 +8,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     @Query("select f from Friend f " +
-            "where (f.sender = :member and f.receiver.profile.name like %:name%)")
-    List<Friend> findAllByName(@Param("member") Member member, @Param("name") String name);       // member 의 친구들 검색
+            "join fetch f.receiver r " +
+            "where f.sender = :member and " +
+            "(:name = '' or r.profile.name like '%' || :name || '%')")
+    Page<Friend> findBySenderAndReceiver_Name(@Param("member") Member member,
+                                            @Param("name") String name,
+                                            Pageable pageable);
 
     @Query("select f from Friend f " +
             "where ((f.sender.id = :senderId and f.receiver.id = :receiverId) " +
@@ -28,7 +31,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     @Query("select f from Friend f " +
             "where ((f.sender.id = :senderId and f.receiver.id = :receiverId) " +
             "or (f.sender.id = :receiverId and f.receiver.id = :senderId))")
-    Optional<Friend> findByMembers(@Param("senderId") Long senderId, @Param("receiverId")Long receiverId);
+    Optional<Friend> findByMembers(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
 
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
 

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -18,9 +18,17 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     List<Friend> findAllByName(@Param("member") Member member, @Param("name") String name);       // member 의 친구들 검색
 
     @Query("select f from Friend f " +
-            "where (f.sender.id = :senderId and f.receiver.id = :receiverId) " +
-            "or (f.sender.id = :receiverId and f.receiver.id = :senderId)")
-    Optional<Friend> findByMembers(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+            "where ((f.sender.id = :senderId and f.receiver.id = :receiverId) " +
+            "or (f.sender.id = :receiverId and f.receiver.id = :senderId)) " +
+            "and (f.acceptance = :acceptance)")
+    Optional<Friend> findByMembersAndAcceptance(@Param("senderId") Long senderId,
+                                                @Param("receiverId") Long receiverId,
+                                                @Param("acceptance") boolean acceptance);
+
+    @Query("select f from Friend f " +
+            "where ((f.sender.id = :senderId and f.receiver.id = :receiverId) " +
+            "or (f.sender.id = :receiverId and f.receiver.id = :senderId))")
+    Optional<Friend> findByMembers(@Param("senderId") Long senderId, @Param("receiverId")Long receiverId);
 
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
 
@@ -31,4 +39,9 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             "where f.receiver = :receiver and f.acceptance = :acceptance")
     Page<Friend> findAllByReceiverAndAcceptance(Member receiver, boolean acceptance, Pageable pageable);
 
+
+//    @Query("select f from Friend f " +
+//            "where (f.sender = :sender and f.receiver = :receiver) " +
+//            "or (f.sender = :receiver and f.receiver = :sender)")
+//    Optional<Friend> findFirstByMembers(Member member, Member friendMember);
 }

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -2,6 +2,8 @@ package kuchat.server.domain.friend.repository;
 
 import kuchat.server.domain.friend.Friend;
 import kuchat.server.domain.member.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,6 +25,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Optional<Friend> findBySenderAndReceiver(Member sender, Member receiver);
 
     Optional<Friend> findByIdAndReceiver_IdAndAcceptance(Long friendId, Long memberId, boolean acceptance);
+
+    Page<Friend> findAllByReceiverAndAcceptance(Member sender, boolean acceptance, Pageable pageable);
 
 //    @Query("select f from Friend f " +
 //            "where (f.sender = :sender and f.receiver = :receiver) " +

--- a/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/kuchat/server/domain/friend/repository/FriendRepository.java
@@ -26,10 +26,9 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     Optional<Friend> findByIdAndReceiver_IdAndAcceptance(Long friendId, Long memberId, boolean acceptance);
 
-    Page<Friend> findAllByReceiverAndAcceptance(Member sender, boolean acceptance, Pageable pageable);
+    @Query("select f from Friend f " +
+            "join fetch f.sender s " +
+            "where f.receiver = :receiver and f.acceptance = :acceptance")
+    Page<Friend> findAllByReceiverAndAcceptance(Member receiver, boolean acceptance, Pageable pageable);
 
-//    @Query("select f from Friend f " +
-//            "where (f.sender = :sender and f.receiver = :receiver) " +
-//            "or (f.sender = :receiver and f.receiver = :sender)")
-//    Optional<Friend> findFirstByMembers(Member member, Member friendMember);
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -34,10 +34,10 @@ public class FriendService {
 
     @Transactional
     public ResponseEntity<BaseResponse> applyByPlusId(Member member, String plusId) {
-        log.info("[addByPlusId] member id = {} 인 사용자가 plus id = {} 인 사용자를 친구로 추가함.", member.getId(), plusId);
+        log.info("[applyByPlusId] member id = {} 인 사용자가 plus id = {} 인 사용자를 친구로 추가함.", member.getId(), plusId);
         Member friendMember = getMemberByPlusId(plusId);
-        validateAlreadyFriend(member, friendMember);
-        validateBlock(member, friendMember);
+        validateAlreadyFriend(member.getId(), friendMember.getId());
+        validateBlock(member.getId(), friendMember.getId());
 
         Friend newFriend = Friend.builder()
                 .sender(member)
@@ -47,31 +47,49 @@ public class FriendService {
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
-    private void validateBlock(Member member, Member friendMember) {
-        if (blockService.isBlockOrBlocked(member.getId(), friendMember.getId())){
+    @Transactional
+    public ResponseEntity<BaseResponse> acceptApply(Long memberId, Long friendId) {
+        log.info("[acceptApply] friendId = {} 인 친구신청을 수신자인 {} 가 수락함", friendId, memberId);
+        friendRepository.findByIdAndReceiver_IdAndAcceptance(friendId, memberId, false)
+                .ifPresentOrElse(
+                        Friend::accept,
+                        () -> {
+                            throw new KuchatException(NOT_FOUND_APPLY);
+                        }
+                );
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
+    }
+
+    private void validateBlock(Long memberId, Long friendMemberId) {
+        if (blockService.isBlockOrBlocked(memberId, friendMemberId)) {
             throw new KuchatException(BLOCKED_MEMBER_APPLY);
         }
     }
 
-    private void validateAlreadyFriend(Member member, Member friendMember) {
-        if (friendRepository.findByMembers(member, friendMember).isPresent()){
+    private void validateAlreadyFriend(Long memberId, Long friendMemberId) {
+        if (friendRepository.findByMembers(memberId, friendMemberId).isPresent()) {
             throw new KuchatException(ALREADY_FRIEND);
         }
     }
 
-    public FriendResponses getFriendList(Member member, String friendName) {
+    public ResponseEntity<BaseResponse> getFriendList(Member member, String friendName) {
         log.info("[getFriendList] 이름에 '{}' 을 포함하는 친구 조회", friendName);
         List<Friend> friendships = friendRepository.findAllByName(member, friendName);
         List<FriendResponse> friendResponse = friendships.stream()
                 .map(Friend::getReceiver)
                 .map(FriendResponse::new)
                 .toList();
-        return new FriendResponses(friendResponse);
+        FriendResponses responses = new FriendResponses(SUCCESS, friendResponse);
+        return ResponseEntity.ok(responses);
     }
 
-    public void delete(Member member, Long friendId) {
-        Member friendMember = getMember(friendId);
-        Optional<Friend> friend = friendRepository.findByMembers(member, friendMember);
+    public ResponseEntity<BaseResponse> delete(Member member, Long friendId) {
+        deleteFriendByMembers(member.getId(), friendId);
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
+    }
+
+    public void deleteFriendByMembers(Long memberId, Long friendMemberId) {
+        Optional<Friend> friend = friendRepository.findByMembers(memberId, friendMemberId);
         friend.ifPresentOrElse(
                 friendRepository::delete,
                 () -> {
@@ -80,13 +98,9 @@ public class FriendService {
         );
     }
 
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
-    }
-
     private Member getMemberByPlusId(String plusId) {
         return memberRepository.findByPlusId(plusId)
                 .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
     }
+
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -11,6 +11,7 @@ import kuchat.server.domain.friend.dto.FriendResponses;
 import kuchat.server.domain.friend.repository.FriendRepository;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
+import kuchat.server.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -20,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
 
@@ -30,15 +30,15 @@ import static kuchat.server.common.response.BaseResponseStatus.*;
 @Service
 public class FriendService {
 
-    private final MemberRepository memberRepository;
     private final FriendRepository friendRepository;
     private final BlockService blockService;
+    private final MemberService memberService;
 
 
     @Transactional
     public ResponseEntity<BaseResponse> applyByPlusId(Member member, String plusId) {
         log.info("[applyByPlusId] member id = {} 인 사용자가 plus id = {} 인 사용자를 친구로 추가함.", member.getId(), plusId);
-        Member friendMember = getMemberByPlusId(plusId);
+        Member friendMember = memberService.getMemberByPlusId(plusId);
         validateAlreadyFriend(member.getId(), friendMember.getId());
         validateBlock(member.getId(), friendMember.getId());
 
@@ -87,32 +87,27 @@ public class FriendService {
     }
 
     @Transactional
-    public ResponseEntity<BaseResponse> delete(Member member, Long friendMemberId) {
+    public ResponseEntity<BaseResponse> delete(Member member, Long friendMemberId, boolean acceptance) {
         log.info("[deleteFriendByMembers] member={}, friend={} 인 친구 관계 삭제", member.getId(), friendMemberId);
-        Optional<Friend> friend = friendRepository.findByMembers(member.getId(), friendMemberId);
-        friend.ifPresentOrElse(
-                friendRepository::delete,
-                () -> {
-                    throw new KuchatException(NOT_FOUND_MEMBER);
-                }
-        );
+        friendRepository.findByMembersAndAcceptance(member.getId(), friendMemberId, acceptance)
+                .ifPresentOrElse(
+                        friendRepository::delete,
+                        () -> {
+                            throw new KuchatException(NOT_FOUND_FRIEND);
+                        }
+                );
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
-    private void deleteFriendByMembers(Long memberId, Long friendMemberId) {
-        log.info("[deleteFriendByMembers] member={}, friend={} 인 친구 관계 삭제", memberId, friendMemberId);
-        Optional<Friend> friend = friendRepository.findByMembers(memberId, friendMemberId);
-        friend.ifPresentOrElse(
-                friendRepository::delete,
-                () -> {
-                    throw new KuchatException(NOT_FOUND_MEMBER);
-                }
-        );
-    }
+    @Transactional
+    public ResponseEntity<BaseResponse> breakFriendship(Member member, Long friendMemberId) {
+        log.info("[breakFriendship] 맞팔 관계를 끊고 일방적인 팔로우 관계로 변경");
+        Friend friend = friendRepository.findByMembersAndAcceptance(member.getId(), friendMemberId, true)
+                .orElseThrow(() -> new KuchatException(NOT_FOUND_FRIEND));
+        Member friendMember = memberService.getMemberById(friendMemberId);
+        friend.unfollow(member, friendMember);
 
-    private Member getMemberByPlusId(String plusId) {
-        return memberRepository.findByPlusId(plusId)
-                .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
     @Transactional
@@ -127,4 +122,5 @@ public class FriendService {
         FriendApplyResponses responses = new FriendApplyResponses(SUCCESS, friends);
         return ResponseEntity.ok(responses);
     }
+
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -83,12 +83,21 @@ public class FriendService {
         return ResponseEntity.ok(responses);
     }
 
-    public ResponseEntity<BaseResponse> delete(Member member, Long friendId) {
-        deleteFriendByMembers(member.getId(), friendId);
+    @Transactional
+    public ResponseEntity<BaseResponse> delete(Member member, Long friendMemberId) {
+        log.info("[deleteFriendByMembers] member={}, friend={} 인 친구 관계 삭제", member.getId(), friendMemberId);
+        Optional<Friend> friend = friendRepository.findByMembers(member.getId(), friendMemberId);
+        friend.ifPresentOrElse(
+                friendRepository::delete,
+                () -> {
+                    throw new KuchatException(NOT_FOUND_MEMBER);
+                }
+        );
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
-    public void deleteFriendByMembers(Long memberId, Long friendMemberId) {
+    private void deleteFriendByMembers(Long memberId, Long friendMemberId) {
+        log.info("[deleteFriendByMembers] member={}, friend={} 인 친구 관계 삭제", memberId, friendMemberId);
         Optional<Friend> friend = friendRepository.findByMembers(memberId, friendMemberId);
         friend.ifPresentOrElse(
                 friendRepository::delete,
@@ -103,4 +112,9 @@ public class FriendService {
                 .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
     }
 
+    @Transactional
+    public void deleteIfFriend(Long memberId, Long friendMemberId) {
+        friendRepository.findByMembers(memberId, friendMemberId).
+                ifPresent(friendRepository::delete);
+    }
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -2,15 +2,12 @@ package kuchat.server.domain.friend.service;
 
 import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.response.BaseResponse;
-import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.block.service.BlockService;
 import kuchat.server.domain.friend.Friend;
 import kuchat.server.domain.friend.dto.FriendApplyResponses;
-import kuchat.server.domain.friend.dto.FriendResponse;
 import kuchat.server.domain.friend.dto.FriendResponses;
 import kuchat.server.domain.friend.repository.FriendRepository;
 import kuchat.server.domain.member.Member;
-import kuchat.server.domain.member.repository.MemberRepository;
 import kuchat.server.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,8 +16,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 import static kuchat.server.common.response.BaseResponseStatus.*;
 
@@ -75,17 +70,6 @@ public class FriendService {
         }
     }
 
-    public ResponseEntity<BaseResponse> getFriendList(Member member, String friendName) {
-        log.info("[getFriendList] 이름에 '{}' 을 포함하는 친구 조회", friendName);
-        List<Friend> friendships = friendRepository.findAllByName(member, friendName);
-        List<FriendResponse> friendResponse = friendships.stream()
-                .map(Friend::getReceiver)
-                .map(FriendResponse::new)
-                .toList();
-        FriendResponses responses = new FriendResponses(SUCCESS, friendResponse);
-        return ResponseEntity.ok(responses);
-    }
-
     @Transactional
     public ResponseEntity<BaseResponse> delete(Member member, Long friendMemberId, boolean acceptance) {
         log.info("[deleteFriendByMembers] member={}, friend={} 인 친구 관계 삭제", member.getId(), friendMemberId);
@@ -123,4 +107,11 @@ public class FriendService {
         return ResponseEntity.ok(responses);
     }
 
+
+    public ResponseEntity<FriendResponses> getFriendList(Member member, String friendName, Pageable pageable) {
+        log.info("[getFriendList] 이름에 '{}' 을 포함하는 친구 조회", friendName);
+        Page<Friend> friends = friendRepository.findBySenderAndReceiver_Name(member, friendName, pageable);
+        FriendResponses responses = new FriendResponses(SUCCESS, friends);
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -5,6 +5,7 @@ import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.block.service.BlockService;
 import kuchat.server.domain.friend.Friend;
+import kuchat.server.domain.friend.dto.FriendApplyResponses;
 import kuchat.server.domain.friend.dto.FriendResponse;
 import kuchat.server.domain.friend.dto.FriendResponses;
 import kuchat.server.domain.friend.repository.FriendRepository;
@@ -12,6 +13,8 @@ import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -116,5 +119,12 @@ public class FriendService {
     public void deleteIfFriend(Long memberId, Long friendMemberId) {
         friendRepository.findByMembers(memberId, friendMemberId).
                 ifPresent(friendRepository::delete);
+    }
+
+    public ResponseEntity<FriendApplyResponses> getFriendApplyList(Member member, Pageable pageable) {
+        log.info("[getFriendApplyList] 친구신청 목록 조회");
+        Page<Friend> friends = friendRepository.findAllByReceiverAndAcceptance(member, false, pageable);
+        FriendApplyResponses responses = new FriendApplyResponses(SUCCESS, friends);
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/kuchat/server/domain/friend/service/FriendService.java
+++ b/src/main/java/kuchat/server/domain/friend/service/FriendService.java
@@ -1,6 +1,7 @@
 package kuchat.server.domain.friend.service;
 
 import kuchat.server.common.exception.KuchatException;
+import kuchat.server.common.response.BaseResponse;
 import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.block.service.BlockService;
 import kuchat.server.domain.friend.Friend;
@@ -11,13 +12,14 @@ import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
-import static kuchat.server.common.response.BaseResponseStatus.BLOCKED_MEMBER;
-import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_MEMBER;
+import static kuchat.server.common.response.BaseResponseStatus.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,26 +31,32 @@ public class FriendService {
     private final FriendRepository friendRepository;
     private final BlockService blockService;
 
-    @Transactional
-    public void addFriend(Member member, Long friendId) {
-        log.info("[addFriend] member = {} 가 receiver id = {} 를 친구로 추가함", member.getId(), friendId);
-        Member friendMember = memberRepository.findById(friendId)
-                .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_MEMBER));
-        Friend newFriend = Friend.builder()
-                .sender(member)
-                .receiver(friendMember).build();
-        friendRepository.save(newFriend);
-    }
 
     @Transactional
-    public void addByPlusId(Member member, String plusId) {
+    public ResponseEntity<BaseResponse> applyByPlusId(Member member, String plusId) {
         log.info("[addByPlusId] member id = {} 인 사용자가 plus id = {} 인 사용자를 친구로 추가함.", member.getId(), plusId);
-        Member friendMember = memberRepository.findByPlusId(plusId)
-                .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
+        Member friendMember = getMemberByPlusId(plusId);
+        validateAlreadyFriend(member, friendMember);
+        validateBlock(member, friendMember);
+
         Friend newFriend = Friend.builder()
                 .sender(member)
-                .receiver(friendMember).build();
+                .receiver(friendMember)
+                .build();
         friendRepository.save(newFriend);
+        return ResponseEntity.ok(new BaseResponse(SUCCESS));
+    }
+
+    private void validateBlock(Member member, Member friendMember) {
+        if (blockService.isBlockOrBlocked(member.getId(), friendMember.getId())){
+            throw new KuchatException(BLOCKED_MEMBER_APPLY);
+        }
+    }
+
+    private void validateAlreadyFriend(Member member, Member friendMember) {
+        if (friendRepository.findByMembers(member, friendMember).isPresent()){
+            throw new KuchatException(ALREADY_FRIEND);
+        }
     }
 
     public FriendResponses getFriendList(Member member, String friendName) {
@@ -61,25 +69,24 @@ public class FriendService {
         return new FriendResponses(friendResponse);
     }
 
-    public FriendResponse getFriendProfile(Long memberId, Long friendId) {
-        log.info("[getFriendProfile] id가 {} 인 친구의 프로필 조회", friendId);
-        // friendId인 멤버를 1. 내가 차단했거나, 2. 상대가 나를 차단한 경우 예외가 발생해야 한다.
-        if (blockService.isBlockOrBlocked(memberId, friendId)) {
-            throw new KuchatException(BLOCKED_MEMBER);
-        }
-        Member friendMember = getMember(friendId);
-        return new FriendResponse(friendMember);
-    }
-
     public void delete(Member member, Long friendId) {
         Member friendMember = getMember(friendId);
-        Friend friend = friendRepository.findByMembers(member, friendMember)
-                .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
-        friendRepository.delete(friend);
+        Optional<Friend> friend = friendRepository.findByMembers(member, friendMember);
+        friend.ifPresentOrElse(
+                friendRepository::delete,
+                () -> {
+                    throw new KuchatException(NOT_FOUND_MEMBER);
+                }
+        );
     }
 
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
+    }
+
+    private Member getMemberByPlusId(String plusId) {
+        return memberRepository.findByPlusId(plusId)
+                .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
     }
 }

--- a/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
+++ b/src/main/java/kuchat/server/domain/member/controller/ProfileController.java
@@ -12,11 +12,15 @@ import kuchat.server.domain.member.dto.ProfileUpdateRequest;
 import kuchat.server.domain.member.service.ProfileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import static kuchat.server.common.response.BaseResponseStatus.NOT_FOUND_IMAGE;
 
 @Slf4j
 @Tag(name = "Profile", description = "프로필")
@@ -64,4 +68,14 @@ public class ProfileController {
                 member.getId(), friendMemberId);
         return profileService.getFriendProfile(member.getId(), friendMemberId);
     }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<BaseResponse> handleMissingImageException(MissingServletRequestParameterException e) {
+        // 클라이언트에서 multipartFile 필드 이름을 잘못 지정했거나, 파일 자체를 전송하지 않은 경우
+        log.error("[handleMissingImageException] 클라이언트 요청에서 multipartFile이 누락된 경우");
+        HttpStatus httpStatus = NOT_FOUND_IMAGE.getHttpStatus();
+        return ResponseEntity.status(httpStatus)
+                .body(new BaseResponse(NOT_FOUND_IMAGE));
+    }
+
 }

--- a/src/main/java/kuchat/server/domain/member/dto/DetailProfileResponse.java
+++ b/src/main/java/kuchat/server/domain/member/dto/DetailProfileResponse.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @NoArgsConstructor
 public class DetailProfileResponse extends BaseResponse {
+    private Long memberId;
     private String plusId;
     private LanguageResponse language;
     private ProfileResponse profile;
@@ -22,6 +23,7 @@ public class DetailProfileResponse extends BaseResponse {
 
     public DetailProfileResponse(Member member) {
         super(BaseResponseStatus.SUCCESS);
+        memberId = member.getId();
         plusId = member.getPlusId();
         profile = new ProfileResponse(member.getProfile());
         language = new LanguageResponse(member.getLanguage());

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import kuchat.server.common.jwt.AuthToken;
 import kuchat.server.common.jwt.JwtTokenService;
 import kuchat.server.common.redis.RedisService;
 import kuchat.server.common.response.BaseResponse;
+import kuchat.server.common.response.BaseResponseStatus;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.SignupRequest;
 import kuchat.server.domain.member.dto.SignupResponse;
@@ -72,4 +73,13 @@ public class MemberService {
         return ResponseEntity.ok(new BaseResponse(SUCCESS));
     }
 
+    public Member getMemberByPlusId(String plusId) {
+        return memberRepository.findByPlusId(plusId)
+                .orElseThrow(() -> new KuchatException(BaseResponseStatus.NOT_FOUND_PLUSID));
+    }
+
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new KuchatException(NOT_FOUND_MEMBER));
+    }
 }

--- a/src/main/java/kuchat/server/domain/member/service/MemberService.java
+++ b/src/main/java/kuchat/server/domain/member/service/MemberService.java
@@ -16,8 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static kuchat.server.common.response.BaseResponseStatus.DUPLICATED_STUDENT_ID;
-import static kuchat.server.common.response.BaseResponseStatus.SUCCESS;
+import static kuchat.server.common.response.BaseResponseStatus.*;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -4,7 +4,7 @@ import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.S3Service;
 import kuchat.server.domain.block.service.BlockService;
-import kuchat.server.domain.friend.repository.FriendRepository;
+import kuchat.server.domain.friend.dto.FriendResponse;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
 import kuchat.server.domain.member.dto.ProfileImageUpdateResponse;
@@ -12,7 +12,6 @@ import kuchat.server.domain.member.dto.ProfileUpdateRequest;
 import kuchat.server.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -81,9 +80,10 @@ public class ProfileService {
     }
 
     public ResponseEntity<BaseResponse> getFriendProfile(Long memberId, Long friendMemberId) {
+        log.info("[getFriendProfile] id가 {} 인 친구의 프로필 조회", friendMemberId);
         Member friend = getMember(friendMemberId);
         if (blockService.isBlockOrBlocked(memberId, friendMemberId)) {
-            throw new KuchatException(new BaseResponse(BLOCKED_MEMBER));
+            throw new KuchatException(new BaseResponse(BLOCKED_MEMBER_PROFILE));
         }
         DetailProfileResponse friendProfileResponse = new DetailProfileResponse(friend);
         return ResponseEntity.ok(friendProfileResponse);

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -4,7 +4,6 @@ import kuchat.server.common.exception.KuchatException;
 import kuchat.server.common.response.BaseResponse;
 import kuchat.server.domain.S3Service;
 import kuchat.server.domain.block.service.BlockService;
-import kuchat.server.domain.friend.dto.FriendResponse;
 import kuchat.server.domain.member.Member;
 import kuchat.server.domain.member.dto.DetailProfileResponse;
 import kuchat.server.domain.member.dto.ProfileImageUpdateResponse;

--- a/src/main/java/kuchat/server/domain/member/service/ProfileService.java
+++ b/src/main/java/kuchat/server/domain/member/service/ProfileService.java
@@ -38,6 +38,16 @@ public class ProfileService {
         return ResponseEntity.ok(new DetailProfileResponse(member));
     }
 
+    public ResponseEntity<BaseResponse> getFriendProfile(Long memberId, Long friendMemberId) {
+        log.info("[getFriendProfile] id가 {} 인 친구의 프로필 조회", friendMemberId);
+        Member friend = getMember(friendMemberId);
+        if (blockService.isBlockOrBlocked(memberId, friendMemberId)) {
+            throw new KuchatException(new BaseResponse(BLOCKED_MEMBER_PROFILE));
+        }
+        DetailProfileResponse friendProfileResponse = new DetailProfileResponse(friend);
+        return ResponseEntity.ok(friendProfileResponse);
+    }
+
     @Transactional
     public ResponseEntity<BaseResponse> updateProfile(Member member, ProfileUpdateRequest request) {
         validateAndUpdatePlusId(member.getId(), request.getPlusId());
@@ -79,15 +89,6 @@ public class ProfileService {
                 );
     }
 
-    public ResponseEntity<BaseResponse> getFriendProfile(Long memberId, Long friendMemberId) {
-        log.info("[getFriendProfile] id가 {} 인 친구의 프로필 조회", friendMemberId);
-        Member friend = getMember(friendMemberId);
-        if (blockService.isBlockOrBlocked(memberId, friendMemberId)) {
-            throw new KuchatException(new BaseResponse(BLOCKED_MEMBER_PROFILE));
-        }
-        DetailProfileResponse friendProfileResponse = new DetailProfileResponse(friend);
-        return ResponseEntity.ok(friendProfileResponse);
-    }
 
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)


### PR DESCRIPTION
## 이슈 번호
Close #29 

## 개요
- 친구 신청 : plus id로 친구 신청
- 친구 신청 수락
- 친구 삭제
- 친구 신청 목록 조회 (페이징 적용)
- 친구 목록 조회 (페이징 적용)
- 사용자 차단
- 사용자 차단 해제
- 내가 차단한 사용자 목록 조회 (페이징 적용)

## 작업사항
### 1. 친구 신청 
- access token의 member id를 통해서 Member 엔티티 조회 1번
- plus id를 통해 친구 신청을 보낼 Member 엔티티 조회 1번
- 둘 사이에 이미 친구 신청이 존재하는지 조회 1번
- 둘 사이에 차단이 존재하는지 조회 1번
- Friend 엔티티 생성 후 저장 1번
⇒ 총 5번

### 2. 친구 신청 수락
- access token의 member id를 통해서 Member 엔티티 조회 1번
- friendId와 receiver가 일치하는 Friend 엔티티 조회 1번
- 트랜잭션 종료 후 변경된 Friend 엔티티에 대한 변경 감지 1번
⇒ 총 3번

### 3. 친구 삭제 
- access token의 member id를 통해서 Member 엔티티 조회 1번 ⇒ A
- A가 {memberId}에게 받은 친구 신청 조회
- 조회된 친구 신청 삭제
⇒ 총 3번

### 4. 친구 신청목록 조회
- access token의 member id를 통해서 Member 엔티티 조회 1번
- 페이징 요청에 따라 조건에 부합하는 Friend 엔티티 조회 1번
   이 때 `join fetch`를 통해 Sender의 엔티티도 함께 조회
⇒ 총 2번

### 5. 친구 목록 조회
- access token의 member id를 통해서 Member 엔티티 조회 1번
- 자신이 친구 신청을 보낸 모든 사용자 (=친구) 목록 조회
⇒ 총 2번

### 6. 사용자 차단
- access token의 member id를 통해서 Member 엔티티 조회 1번
- 두 사람이 친구관계인지 아닌지 조회 1번
- 만약 친구관계면 삭제 1번 (친구가 아니면 쿼리문 추가 발생X)
- 두 사람 사이에 차단이 이미 존재하는지 조회 1번
- 친구 id로 회원 조회 1번
- Block 엔티티 생성 후 저장 1번
⇒ 총 5~6번

### 7. 사용자 차단 해제
- access token의 member id를 통해서 Member 엔티티 조회 1번
- 차단당한 친구를 member id를 통해 조회 1번
- Block 엔티티 조회 1번
- 조회된 Block 엔티티를 제거 1번
⇒ 총 4번

### 8. 내가 차단한 사용자 목록 조회
- access token의 member id를 통해서 Member 엔티티 조회 1번
- 내가 차단한 모든 사용자를 조회 1번
⇒ 총 2번